### PR TITLE
Drop currently unused counters

### DIFF
--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -24,9 +24,7 @@ namespace verona::rt
     //  the core's queue. This is necessary to take into account core-stealing
     //  to avoid spawning many threads on a core hogged by a long running
     //  behaviour but with an empty cown queue.
-    std::atomic<std::size_t> progress_counter = 0;
     std::atomic<std::size_t> servicing_threads = 0;
-    std::atomic<std::size_t> last_worker = 0;
 
     SchedulerStats stats;
 

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -182,9 +182,6 @@ namespace verona::rt
 
         Logging::cout() << "Schedule cown " << cown << Logging::endl;
 
-        core->progress_counter++;
-        core->last_worker = systematic_id;
-
         bool reschedule = cown->run(*alloc);
 
         if (reschedule)


### PR DESCRIPTION
These counters are not currently used.  They are currently showing up in profiles. We have an alternative design, that will be implemented in a future PR.  This just removes the counters to improve performance.