### PR TITLE
Pull apart functionality from Cown

### DIFF
--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -538,7 +538,7 @@ namespace verona::rt
       get_header().bits = (get_header().bits & ~MASK) | (uint8_t)RegionMD::RC;
     }
 
-    inline void make_cown()
+    inline void make_shared()
     {
       get_header().bits = (size_t)RegionMD::SHARED + ONE_RC;
     }

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -389,6 +389,7 @@ namespace verona::rt
 
   private:
     friend class Cown;
+    friend class Shared;
     friend void notify(Cown*);
     friend class Immutable;
     friend class Freeze;

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -39,7 +39,7 @@ namespace verona::rt
    *  SCC_PTR  |  Union-find parent pointer for SCC           | Immutable object
    *  Pending  |  Depth of longest chain in SCC               | Immutable object
    *  Shared   |  Reference count                             | Shared object
-   *           |                                              |  (e.g. Cown) 
+   *           |                                              |  (e.g. Cown)
    *  Open ISO |  Region specific scratch space               | Root of region
    *
    *

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -38,7 +38,8 @@ namespace verona::rt
    *  Immutable|  Reference count                             | Immutable object
    *  SCC_PTR  |  Union-find parent pointer for SCC           | Immutable object
    *  Pending  |  Depth of longest chain in SCC               | Immutable object
-   *  Cown     |  Reference count                             | Cown object
+   *  Shared   |  Reference count                             | Shared object
+   *           |                                              |  (e.g. Cown) 
    *  Open ISO |  Region specific scratch space               | Root of region
    *
    *
@@ -678,7 +679,8 @@ namespace verona::rt
     // Returns true if you are incrementing from zero.
     inline bool incref()
     {
-      assert((get_class() == RegionMD::RC) || (get_class() == RegionMD::SHARED));
+      assert(
+        (get_class() == RegionMD::RC) || (get_class() == RegionMD::SHARED));
 
       return get_header().rc.fetch_add(ONE_RC) == get_class();
     }

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -342,7 +342,7 @@ namespace verona::rt
       }
     }
 
-    bool debug_is_cown()
+    bool debug_is_shared()
     {
       return get_class() == RegionMD::COWN;
     }
@@ -715,19 +715,19 @@ namespace verona::rt
       (((size_t)1) << (((sizeof(size_t)) * 8) - 1)) + (size_t)RegionMD::COWN;
 
     /**
-     * Returns true, if this was the last decref on the cown.  If this returns
-     * true all future, and parallel, calls to incref_cown_from_weak will return
-     * false.
+     * Returns true, if this was the last decref on the shared object.  If this
+     *returns true all future, and parallel, calls to acquire_strong_from_weak
+     *will return false.
      **/
-    inline bool decref_cown(bool& release_weak)
+    inline bool decref_shared(bool& release_weak)
     {
-      Logging::cout() << "decref_cown " << (void*)this << std::endl;
-      // This always performs the atomic subtraction, since the cown should
-      // see its own rc as zero this is due to how weak reference to cowns
-      // interact.  An attempt to acquire a weak reference will increase the
-      // strong count.
-      // The top bit of the strong count is set to indicate that the strong
-      // count has reached zero, and future weak count increase should fail.
+      Logging::cout() << "decref_shared " << (void*)this << std::endl;
+      // This always performs the atomic subtraction, since the shared object
+      // should see its own rc as zero this is due to how weak reference to
+      // shared objects interact.  An attempt to acquire a weak reference will
+      // increase the strong count. The top bit of the strong count is set to
+      // indicate that the strong count has reached zero, and future weak count
+      // increase should fail.
       assert(debug_rc() != 0);
       assert(get_header().rc < FINISHED_RC);
       assert(get_class() == RegionMD::COWN);
@@ -740,7 +740,7 @@ namespace verona::rt
 
       yield();
 
-      Logging::cout() << "decref_cown part 2" << (void*)this << std::endl;
+      Logging::cout() << "decref_shared part 2" << (void*)this << std::endl;
       size_t zero_rc = (size_t)RegionMD::COWN;
       auto result =
         get_header().rc.compare_exchange_strong(zero_rc, FINISHED_RC);

--- a/src/rt/region/externalreference.h
+++ b/src/rt/region/externalreference.h
@@ -71,7 +71,7 @@ namespace verona::rt
        */
       static ExternalRef* create(ExternalReferenceTable* ert, Object* o)
       {
-        assert(!o->debug_is_immutable() && !o->debug_is_cown());
+        assert(!o->debug_is_immutable() && !o->debug_is_shared());
         if (o->has_ext_ref())
         {
           auto ext_ref = find_ext_ref(ert, o);

--- a/src/rt/region/freeze.h
+++ b/src/rt/region/freeze.h
@@ -109,7 +109,7 @@ namespace verona::rt
    *    `PENDING` then this is part of an SCC that is still being calculated.
    *    If via a series of zero of more SCC_PTR this points to an
    *    `RC_NON_ATOMIC`, then this is part of a completed SCC.
-   *  * `Object::RC` and `Object::COWN` refer to immutable objects outside the
+   *  * `Object::RC` and `Object::SHARED` refer to immutable objects outside the
    *    current isolate.
    *
    * The objects stack is used to keep track of the set of objects in the
@@ -234,7 +234,7 @@ namespace verona::rt
             }
 
             case Object::RC:
-            case Object::COWN:
+            case Object::SHARED:
             {
               Logging::cout()
                 << "External reference during freeze: " << r << Logging::endl;

--- a/src/rt/region/immutable.h
+++ b/src/rt/region/immutable.h
@@ -135,7 +135,7 @@ namespace verona::rt
           break;
         }
 
-        case Object::COWN:
+        case Object::SHARED:
         {
           Logging::cout() << "Immutable releasing cown: " << w << Logging::endl;
           cown::release(alloc, (Cown*)w);

--- a/src/rt/region/immutable.h
+++ b/src/rt/region/immutable.h
@@ -11,7 +11,7 @@ namespace verona::rt
   namespace shared
   {
     // This is used only to break a dependency cycle.
-    inline void release(Alloc& alloc, Shared* o);
+    inline void release(Alloc& alloc, Object* o);
   } // namespace shared
 
   class Immutable

--- a/src/rt/region/immutable.h
+++ b/src/rt/region/immutable.h
@@ -7,12 +7,12 @@
 
 namespace verona::rt
 {
-  class Cown;
-  namespace cown
+  class Shared;
+  namespace shared
   {
     // This is used only to break a dependency cycle.
-    inline void release(Alloc& alloc, Cown* o);
-  } // namespace cown
+    inline void release(Alloc& alloc, Shared* o);
+  } // namespace shared
 
   class Immutable
   {
@@ -138,7 +138,7 @@ namespace verona::rt
         case Object::SHARED:
         {
           Logging::cout() << "Immutable releasing cown: " << w << Logging::endl;
-          cown::release(alloc, (Cown*)w);
+          shared::release(alloc, w);
           break;
         }
 

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -329,7 +329,7 @@ namespace verona::rt
     template<TransferOwnership transfer = NoTransfer>
     static void insert(Alloc& alloc, Object* into, Object* o)
     {
-      assert(o->debug_is_immutable() || o->debug_is_cown());
+      assert(o->debug_is_immutable() || o->debug_is_shared());
       RegionArena* reg = get(into);
 
       Object::RegionMD c;

--- a/src/rt/region/region_rc.h
+++ b/src/rt/region/region_rc.h
@@ -289,7 +289,7 @@ namespace verona::rt
           case Object::RC:
             f->decref();
             break;
-          case Object::COWN:
+          case Object::SHARED:
             cown::release(alloc, (Cown*)f);
             break;
           case Object::ISO:
@@ -350,7 +350,7 @@ namespace verona::rt
           case Object::RC:
             p->decref();
             break;
-          case Object::COWN:
+          case Object::SHARED:
             cown::release(alloc, (Cown*)p);
             break;
           default:
@@ -550,7 +550,7 @@ namespace verona::rt
           case Object::RC:
             f->decref();
             break;
-          case Object::COWN:
+          case Object::SHARED:
             cown::release(alloc, (Cown*)f);
             break;
           case Object::ISO:
@@ -620,7 +620,7 @@ namespace verona::rt
           case Object::RC:
             p->decref();
             break;
-          case Object::COWN:
+          case Object::SHARED:
             cown::release(alloc, (Cown*)p);
             break;
           case Object::ISO:

--- a/src/rt/region/region_rc.h
+++ b/src/rt/region/region_rc.h
@@ -290,7 +290,7 @@ namespace verona::rt
             f->decref();
             break;
           case Object::SHARED:
-            cown::release(alloc, (Cown*)f);
+            shared::release(alloc, f);
             break;
           case Object::ISO:
             assert(f != o);
@@ -351,7 +351,7 @@ namespace verona::rt
             p->decref();
             break;
           case Object::SHARED:
-            cown::release(alloc, (Cown*)p);
+            shared::release(alloc, p);
             break;
           default:
             assert(0);
@@ -551,7 +551,7 @@ namespace verona::rt
             f->decref();
             break;
           case Object::SHARED:
-            cown::release(alloc, (Cown*)f);
+            shared::release(alloc, f);
             break;
           case Object::ISO:
             // Deallocation should only happen on an opened region.
@@ -621,7 +621,7 @@ namespace verona::rt
             p->decref();
             break;
           case Object::SHARED:
-            cown::release(alloc, (Cown*)p);
+            shared::release(alloc, p);
             break;
           case Object::ISO:
             //            assert(p != in);

--- a/src/rt/region/region_trace.h
+++ b/src/rt/region/region_trace.h
@@ -422,7 +422,7 @@ namespace verona::rt
             break;
 
           case Object::RC:
-          case Object::COWN:
+          case Object::SHARED:
             RememberedSet::mark(alloc, p);
             break;
 

--- a/src/rt/region/region_trace.h
+++ b/src/rt/region/region_trace.h
@@ -171,7 +171,7 @@ namespace verona::rt
     template<TransferOwnership transfer = NoTransfer>
     static void insert(Alloc& alloc, Object* into, Object* o)
     {
-      assert(o->debug_is_immutable() || o->debug_is_cown());
+      assert(o->debug_is_immutable() || o->debug_is_shared());
       RegionTrace* reg = get(into);
 
       Object::RegionMD c;

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -136,7 +136,7 @@ namespace verona::rt
           break;
         }
 
-        case Object::COWN:
+        case Object::SHARED:
         {
           Logging::cout() << "RS releasing: cown: " << o << Logging::endl;
           cown::release(alloc, (Cown*)o);

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -139,7 +139,7 @@ namespace verona::rt
         case Object::SHARED:
         {
           Logging::cout() << "RS releasing: cown: " << o << Logging::endl;
-          cown::release(alloc, (Cown*)o);
+          shared::release(alloc, o);
           break;
         }
 

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -55,7 +55,7 @@ namespace verona::rt
     template<TransferOwnership transfer>
     void insert(Alloc& alloc, Object* o)
     {
-      assert(o->debug_is_rc() || o->debug_is_cown());
+      assert(o->debug_is_rc() || o->debug_is_shared());
 
       // If the caller is not transfering ownership of a refcount, i.e., the
       // object is being added to the region but not dropped from somewhere,
@@ -79,7 +79,7 @@ namespace verona::rt
      */
     void mark(Alloc& alloc, Object* o)
     {
-      assert(o->debug_is_rc() || o->debug_is_cown());
+      assert(o->debug_is_rc() || o->debug_is_shared());
 
       auto r = hash_set->insert(alloc, o);
       if (r.first)

--- a/src/rt/sched/behaviour.h
+++ b/src/rt/sched/behaviour.h
@@ -419,7 +419,7 @@ namespace verona::rt
         yield();
         Logging::cout() << "No more work for cown " << cown << Logging::endl;
         // Success, no successor, release scheduler threads reference count.
-        cown::release(ThreadAlloc::get(), cown);
+        shared::release(ThreadAlloc::get(), cown);
         return;
       }
 

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -91,9 +91,7 @@ namespace verona::rt
   class Cown : public Shared
   {
   public:
-    Cown()
-    {
-    }
+    Cown() {}
 
   private:
     friend Core;

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -9,6 +9,7 @@
 #include "base_noticeboard.h"
 #include "core.h"
 #include "schedulerthread.h"
+#include "shared.h"
 
 #include <algorithm>
 #include <vector>
@@ -87,12 +88,11 @@ namespace verona::rt
 
   struct Slot;
 
-  class Cown : public Object
+  class Cown : public Shared
   {
   public:
     Cown()
     {
-      make_cown();
     }
 
   private:
@@ -106,13 +106,6 @@ namespace verona::rt
     friend class Noticeboard;
 
     std::atomic<Slot*> last_slot{nullptr};
-
-    /**
-     * Cown's weak reference count.  This keeps the cown itself alive, but not
-     * the data it can reach.  Weak reference can be promoted to strong, if a
-     * strong reference still exists.
-     **/
-    std::atomic<size_t> weak_count{1};
 
     /*
      * Cown's read ref count.
@@ -148,84 +141,6 @@ namespace verona::rt
 
 #endif
 
-    static void acquire(Object* o)
-    {
-      Logging::cout() << "Cown " << o << " acquire" << Logging::endl;
-      assert(o->debug_is_cown());
-      o->incref();
-    }
-
-    static void release(Alloc& alloc, Cown* o)
-    {
-      Logging::cout() << "Cown " << o << " release" << Logging::endl;
-      assert(o->debug_is_cown());
-      Cown* a = ((Cown*)o);
-
-      // Perform decref
-      auto release_weak = false;
-      bool last = o->decref_cown(release_weak);
-
-      yield();
-
-      if (release_weak)
-      {
-        o->weak_release(alloc);
-        yield();
-      }
-
-      if (!last)
-        return;
-
-      // All paths from this point must release the weak count owned by the
-      // strong count.
-
-      Logging::cout() << "Cown " << o << " dealloc" << Logging::endl;
-
-      // If last, then collect the cown body.
-      a->queue_collect(alloc);
-    }
-
-    /**
-     * Release a weak reference to this cown.
-     **/
-    void weak_release(Alloc& alloc)
-    {
-      Logging::cout() << "Cown " << this << " weak release" << Logging::endl;
-      if (weak_count.fetch_sub(1) == 1)
-      {
-        yield();
-
-        Logging::cout() << "Cown " << this << " no references left."
-                        << Logging::endl;
-        dealloc(alloc);
-      }
-    }
-
-    void weak_acquire()
-    {
-      Logging::cout() << "Cown " << this << " weak acquire" << Logging::endl;
-      assert(weak_count > 0);
-      weak_count++;
-    }
-
-    /**
-     * Gets a strong reference from a weak reference.
-     *
-     * Weak reference is preserved.
-     *
-     * Returns true is strong reference created.
-     **/
-    bool acquire_strong_from_weak()
-    {
-      bool reacquire_weak = false;
-      auto result = Object::acquire_strong_from_weak(reacquire_weak);
-      if (reacquire_weak)
-      {
-        weak_acquire();
-      }
-      return result;
-    }
-
     // void mark_notify()
     // {
     //   if (queue.mark_notify())
@@ -237,12 +152,6 @@ namespace verona::rt
     // }
 
   private:
-    void dealloc(Alloc& alloc)
-    {
-      Object::dealloc(alloc);
-      yield();
-    }
-
     // void cown_notified()
     // {
     //   // This is not a message make sure we know that.
@@ -255,93 +164,6 @@ namespace verona::rt
     // }
 
   public:
-    /**
-     * Called when strong reference count reaches one.
-     * Uses thread_local state to deal with deep deallocation
-     * chains by queuing recursive calls.
-     **/
-    void queue_collect(Alloc& alloc)
-    {
-      thread_local ObjectStack* work_list = nullptr;
-
-      // If there is a already a queue, use it
-      if (work_list != nullptr)
-      {
-        // This is a recursive call, add to queue
-        // and return immediately.
-        work_list->push(this);
-        return;
-      }
-
-      // Make queue for recursive deallocations.
-      ObjectStack current(alloc);
-      work_list = &current;
-
-      // Collect the current cown
-      collect(alloc);
-      yield();
-      weak_release(alloc);
-
-      // Collect recursively reachable cowns
-      while (!current.empty())
-      {
-        auto a = (Cown*)current.pop();
-        a->collect(alloc);
-        yield();
-        a->weak_release(alloc);
-      }
-      work_list = nullptr;
-    }
-
-    void collect(Alloc& alloc)
-    {
-#ifdef USE_SYSTEMATIC_TESTING_WEAK_NOTICEBOARDS
-      flush_all(alloc);
-#endif
-      Logging::cout() << "Collecting cown " << this << Logging::endl;
-
-      ObjectStack dummy(alloc);
-      // Run finaliser before releasing our data.
-      // Sub-regions handled by code below.
-      finalise(nullptr, dummy);
-
-      // TODO?
-      // Release our data.
-      ObjectStack f(alloc);
-      trace(f);
-
-      while (!f.empty())
-      {
-        Object* o = f.pop();
-
-        switch (o->get_class())
-        {
-          case RegionMD::ISO:
-            Region::release(alloc, o);
-            break;
-
-          case RegionMD::RC:
-          case RegionMD::SCC_PTR:
-            Immutable::release(alloc, o);
-            break;
-
-          case RegionMD::COWN:
-            Logging::cout()
-              << "DecRef from " << this << " to " << o << Logging::endl;
-            Cown::release(alloc, (Cown*)o);
-            break;
-
-          default:
-            abort();
-        }
-      }
-
-      yield();
-
-      // Now we may run our destructor.
-      destructor();
-    }
-
     // bool release_early()
     // {
     //   auto* body = Scheduler::local()->message_body;
@@ -385,7 +207,7 @@ namespace verona::rt
   {
     inline void release(Alloc& alloc, Cown* o)
     {
-      Cown::release(alloc, o);
+      Shared::release(alloc, o);
     }
   } // namespace cown
 } // namespace verona::rt

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -202,12 +202,4 @@ namespace verona::rt
     //   return true;
     // }
   };
-
-  namespace cown
-  {
-    inline void release(Alloc& alloc, Cown* o)
-    {
-      Shared::release(alloc, o);
-    }
-  } // namespace cown
 } // namespace verona::rt

--- a/src/rt/sched/shared.h
+++ b/src/rt/sched/shared.h
@@ -208,4 +208,13 @@ namespace verona::rt
       destructor();
     }
   };
+
+  namespace shared
+  {
+    inline void release(Alloc& alloc, Object* o)
+    {
+      assert(o->debug_is_shared());
+      Shared::release(alloc, (Shared*)o);
+    }
+  } // namespace cown
 } // namespace verona::rt

--- a/src/rt/sched/shared.h
+++ b/src/rt/sched/shared.h
@@ -19,7 +19,6 @@ namespace verona::rt
    * [TODO A Notify as another subclass of Shared]
    */
 
-
   class Shared : public Object
   {
   public:
@@ -31,9 +30,9 @@ namespace verona::rt
 
   private:
     /**
-     * Shared object's weak reference count.  This keeps the Shared object itself alive, but not
-     * the data it can reach.  Weak reference can be promoted to strong, if a
-     * strong reference still exists.
+     * Shared object's weak reference count.  This keeps the Shared object
+     *itself alive, but not the data it can reach.  Weak reference can be
+     *promoted to strong, if a strong reference still exists.
      **/
     std::atomic<size_t> weak_count{1};
 
@@ -41,20 +40,18 @@ namespace verona::rt
     static void acquire(Object* o)
     {
       Logging::cout() << "Shared " << o << " acquire" << Logging::endl;
-      // TODO debug_is_cown -> debug_is_shared
-      assert(o->debug_is_cown());
+      assert(o->debug_is_shared());
       o->incref();
     }
 
     static void release(Alloc& alloc, Shared* o)
     {
       Logging::cout() << "Shared " << o << " release" << Logging::endl;
-      assert(o->debug_is_cown());
+      assert(o->debug_is_shared());
 
       // Perform decref
       auto release_weak = false;
-      // TODO decref_cown -> decref_shared
-      bool last = o->decref_cown(release_weak);
+      bool last = o->decref_shared(release_weak);
 
       yield();
 

--- a/src/rt/sched/shared.h
+++ b/src/rt/sched/shared.h
@@ -172,7 +172,6 @@ namespace verona::rt
       // Sub-regions handled by code below.
       finalise(nullptr, dummy);
 
-      // TODO?
       // Release our data.
       ObjectStack f(alloc);
       trace(f);

--- a/src/rt/sched/shared.h
+++ b/src/rt/sched/shared.h
@@ -192,7 +192,7 @@ namespace verona::rt
             Immutable::release(alloc, o);
             break;
 
-          case RegionMD::COWN:
+          case RegionMD::SHARED:
             Logging::cout()
               << "DecRef from " << this << " to " << o << Logging::endl;
             Shared::release(alloc, (Shared*)o);

--- a/src/rt/sched/shared.h
+++ b/src/rt/sched/shared.h
@@ -24,8 +24,7 @@ namespace verona::rt
   public:
     Shared()
     {
-      // TODO replace make_cown with make_shared
-      make_cown();
+      make_shared();
     }
 
   private:
@@ -163,6 +162,7 @@ namespace verona::rt
     {
 #ifdef USE_SYSTEMATIC_TESTING_WEAK_NOTICEBOARDS
 // TODO THINK
+//      Move to finalisers for noticeboards.
 //      flush_all(alloc);
 #endif
       Logging::cout() << "Collecting cown " << this << Logging::endl;

--- a/src/rt/sched/shared.h
+++ b/src/rt/sched/shared.h
@@ -1,0 +1,215 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "../debug/logging.h"
+#include "../debug/systematic.h"
+#include "../ds/forward_list.h"
+#include "../region/region.h"
+#include "base_noticeboard.h"
+#include "core.h"
+#include "schedulerthread.h"
+
+namespace verona::rt
+{
+  /**
+   * Shared wrapper that encapsulates the implementation of memory management
+   * for Shared objects in the verona runtime.
+   * This is extended to give other forms of Shared objects, such as Cowns.
+   * [TODO A Notify as another subclass of Shared]
+   */
+
+
+  class Shared : public Object
+  {
+  public:
+    Shared()
+    {
+      // TODO replace make_cown with make_shared
+      make_cown();
+    }
+
+  private:
+    /**
+     * Shared object's weak reference count.  This keeps the Shared object itself alive, but not
+     * the data it can reach.  Weak reference can be promoted to strong, if a
+     * strong reference still exists.
+     **/
+    std::atomic<size_t> weak_count{1};
+
+  public:
+    static void acquire(Object* o)
+    {
+      Logging::cout() << "Shared " << o << " acquire" << Logging::endl;
+      // TODO debug_is_cown -> debug_is_shared
+      assert(o->debug_is_cown());
+      o->incref();
+    }
+
+    static void release(Alloc& alloc, Shared* o)
+    {
+      Logging::cout() << "Shared " << o << " release" << Logging::endl;
+      assert(o->debug_is_cown());
+
+      // Perform decref
+      auto release_weak = false;
+      // TODO decref_cown -> decref_shared
+      bool last = o->decref_cown(release_weak);
+
+      yield();
+
+      if (release_weak)
+      {
+        o->weak_release(alloc);
+        yield();
+      }
+
+      if (!last)
+        return;
+
+      // All paths from this point must release the weak count owned by the
+      // strong count.
+
+      Logging::cout() << "Cown " << o << " dealloc" << Logging::endl;
+
+      // If last, then collect the cown body.
+      o->queue_collect(alloc);
+    }
+
+    /**
+     * Release a weak reference to this cown.
+     **/
+    void weak_release(Alloc& alloc)
+    {
+      Logging::cout() << "Cown " << this << " weak release" << Logging::endl;
+      if (weak_count.fetch_sub(1) == 1)
+      {
+        yield();
+
+        Logging::cout() << "Cown " << this << " no references left."
+                        << Logging::endl;
+        dealloc(alloc);
+      }
+    }
+
+    void weak_acquire()
+    {
+      Logging::cout() << "Cown " << this << " weak acquire" << Logging::endl;
+      assert(weak_count > 0);
+      weak_count++;
+    }
+
+    /**
+     * Gets a strong reference from a weak reference.
+     *
+     * Weak reference is preserved.
+     *
+     * Returns true is strong reference created.
+     **/
+    bool acquire_strong_from_weak()
+    {
+      bool reacquire_weak = false;
+      auto result = Object::acquire_strong_from_weak(reacquire_weak);
+      if (reacquire_weak)
+      {
+        weak_acquire();
+      }
+      return result;
+    }
+
+  private:
+    void dealloc(Alloc& alloc)
+    {
+      Object::dealloc(alloc);
+      yield();
+    }
+
+    /**
+     * Called when strong reference count reaches one.
+     * Uses thread_local state to deal with deep deallocation
+     * chains by queuing recursive calls.
+     **/
+    void queue_collect(Alloc& alloc)
+    {
+      thread_local ObjectStack* work_list = nullptr;
+
+      // If there is a already a queue, use it
+      if (work_list != nullptr)
+      {
+        // This is a recursive call, add to queue
+        // and return immediately.
+        work_list->push(this);
+        return;
+      }
+
+      // Make queue for recursive deallocations.
+      ObjectStack current(alloc);
+      work_list = &current;
+
+      // Collect the current cown
+      collect(alloc);
+      yield();
+      weak_release(alloc);
+
+      // Collect recursively reachable cowns
+      while (!current.empty())
+      {
+        auto a = (Shared*)current.pop();
+        a->collect(alloc);
+        yield();
+        a->weak_release(alloc);
+      }
+      work_list = nullptr;
+    }
+
+    void collect(Alloc& alloc)
+    {
+#ifdef USE_SYSTEMATIC_TESTING_WEAK_NOTICEBOARDS
+// TODO THINK
+//      flush_all(alloc);
+#endif
+      Logging::cout() << "Collecting cown " << this << Logging::endl;
+
+      ObjectStack dummy(alloc);
+      // Run finaliser before releasing our data.
+      // Sub-regions handled by code below.
+      finalise(nullptr, dummy);
+
+      // TODO?
+      // Release our data.
+      ObjectStack f(alloc);
+      trace(f);
+
+      while (!f.empty())
+      {
+        Object* o = f.pop();
+
+        switch (o->get_class())
+        {
+          case RegionMD::ISO:
+            Region::release(alloc, o);
+            break;
+
+          case RegionMD::RC:
+          case RegionMD::SCC_PTR:
+            Immutable::release(alloc, o);
+            break;
+
+          case RegionMD::COWN:
+            Logging::cout()
+              << "DecRef from " << this << " to " << o << Logging::endl;
+            Shared::release(alloc, (Shared*)o);
+            break;
+
+          default:
+            abort();
+        }
+      }
+
+      yield();
+
+      // Now we may run our destructor.
+      destructor();
+    }
+  };
+} // namespace verona::rt


### PR DESCRIPTION
The Cown class has two pieces of functionality

* Lifetime management with strong and weak references
* Structures for participating in behaviours

The second is completely specific to Cowns, but the first could be useful for other things in the runtime.  This PR pulls those apart.  The runtime now understands some objects are RegionMD::SHARED and should be managed using strong and weak reference counts. 

This PR is to enable other features to be added such as Notifications and Noticeboards in a more primitive way.  Those additions and refactorings will be in two subsequent PRs.