### PR TITLE
Fix memory model in Asymmetric Lock.

### DIFF
--- a/src/rt/ds/asymlock.h
+++ b/src/rt/ds/asymlock.h
@@ -81,7 +81,7 @@ namespace verona::rt
 
       Barrier::compiler();
 
-      if (external_lock.load(std::memory_order_relaxed))
+      if (external_lock.load(std::memory_order_acquire))
       {
         internal_acquire_rare();
       }

--- a/test/func/asymlock/asymlock.cc
+++ b/test/func/asymlock/asymlock.cc
@@ -1,0 +1,114 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+/**
+ * This files contains a collection of simple races on the asymmetric lock.
+ * The tests should be run with Thread Sanitizer to detect potential races.
+ */
+
+#include <ds/asymlock.h>
+#include <thread>
+
+/**
+ * Test a basic race between internal and external acquire.
+ */
+void test_race0()
+{
+  verona::rt::AsymmetricLock lock;
+  size_t protected_value = 0;
+
+  // Internal thread
+  auto it = std::thread([&lock, &protected_value]() {
+    lock.internal_acquire();
+    auto l = protected_value;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    protected_value = l + 1;
+    lock.internal_release();
+  });
+
+  // External thread
+  auto et = std::thread([&lock, &protected_value]() {
+    lock.external_acquire();
+    auto l = protected_value;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    protected_value = l + 2;
+    lock.external_release();
+  });
+
+  et.join();
+  it.join();
+
+  SNMALLOC_CHECK(protected_value == 3);
+}
+
+/**
+ * Test racing between internal release and external acquire.
+ */
+void test_race1()
+{
+  verona::rt::AsymmetricLock lock;
+  size_t protected_value = 0;
+  std::atomic<bool> go(false);
+
+  // Internal thread
+  auto it = std::thread([&go, &lock, &protected_value]() {
+    lock.internal_acquire();
+    go = true;
+    protected_value++;
+    lock.internal_release();
+  });
+
+  // External thread
+  auto et = std::thread([&go, &lock, &protected_value]() {
+    while (!go)
+    {
+    } // Spin until internal thread has acquired the lock
+    lock.external_acquire();
+    protected_value++;
+    lock.external_release();
+  });
+
+  et.join();
+  it.join();
+
+  SNMALLOC_CHECK(protected_value == 2);
+}
+
+/**
+ * Test racing between external release and internal acquire.
+ */
+void test_race2()
+{
+  verona::rt::AsymmetricLock lock;
+  size_t protected_value = 0;
+  std::atomic<bool> go(false);
+
+  // External thread
+  auto et = std::thread([&go, &lock, &protected_value]() {
+    lock.external_acquire();
+    go = true;
+    protected_value++;
+    lock.external_release();
+  });
+  // Internal thread
+  auto it = std::thread([&go, &lock, &protected_value]() {
+    while (!go)
+      ;
+    lock.internal_acquire();
+    protected_value++;
+    lock.internal_release();
+  });
+
+  et.join();
+  it.join();
+
+  SNMALLOC_CHECK(protected_value == 2);
+}
+
+int main()
+{
+  test_race0();
+  test_race1();
+  test_race2();
+  return 0;
+}


### PR DESCRIPTION
The manipulation of `external_lock` inside the `internal` operations needs to use `acquire/release` semantics.

This PR adds a missing `acquire`, and tests to be used with TSAN to check that the semantics is "probably" not racy.

This issue was found by Graham Harper.