### PR TITLE
Fixing acquiring a cown multiple times.

### DIFF
--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -201,7 +201,6 @@ namespace verona::cpp
           return;
 
         BehaviourCore* barray[sizeof...(Args)];
-
         create_behaviour(barray);
 
         BehaviourCore::schedule_many(barray, sizeof...(Args));

--- a/src/rt/sched/behaviour.h
+++ b/src/rt/sched/behaviour.h
@@ -101,13 +101,6 @@ namespace verona::rt
     static Behaviour*
     prepare_to_schedule(size_t count, Request* requests, Args&&... args)
     {
-      // auto compare = [](Request r1, Request r2) {
-      //     return r1.cown() < r2.cown();
-      //   };
-      // std::sort(requests, requests + count, compare);
-      // auto end = std::unique(requests, requests + count, compare);
-      // count = end - requests - 1;
-
       auto body = Behaviour::make<Be>(count, std::forward<Args>(args)...);
 
       auto* slots = body->get_slots();

--- a/src/rt/sched/behaviour.h
+++ b/src/rt/sched/behaviour.h
@@ -101,6 +101,13 @@ namespace verona::rt
     static Behaviour*
     prepare_to_schedule(size_t count, Request* requests, Args&&... args)
     {
+      // auto compare = [](Request r1, Request r2) {
+      //     return r1.cown() < r2.cown();
+      //   };
+      // std::sort(requests, requests + count, compare);
+      // auto end = std::unique(requests, requests + count, compare);
+      // count = end - requests - 1;
+
       auto body = Behaviour::make<Be>(count, std::forward<Args>(args)...);
 
       auto* slots = body->get_slots();

--- a/test/func/dynamic-cownset/dynamic-cownset.cc
+++ b/test/func/dynamic-cownset/dynamic-cownset.cc
@@ -251,6 +251,22 @@ void test_move()
     [=](auto) { Logging::cout() << "log" << Logging::endl; };
 }
 
+void test_repeated_cown()
+{
+  Logging::cout() << "test_repeated_cown()" << Logging::endl;
+
+  auto log1 = make_cown<Body1>(1);
+
+  cown_ptr<Body1> carray[2];
+  carray[0] = log1;
+  carray[1] = log1;
+
+  cown_array<Body1> t1{carray, 2};
+
+  when(std::move(t1)) <<
+    [=](auto) { Logging::cout() << "log" << Logging::endl; };
+}
+
 int main(int argc, char** argv)
 {
   SystematicTestHarness harness(argc, argv);
@@ -271,6 +287,8 @@ int main(int argc, char** argv)
   harness.run(test_nest2);
 
   harness.run(test_move);
+
+  harness.run(test_repeated_cown);
 
   return 0;
 }

--- a/test/func/when-repeated-cown/repeat-cown.cc
+++ b/test/func/when-repeated-cown/repeat-cown.cc
@@ -1,0 +1,36 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <cpp/when.h>
+#include <debug/harness.h>
+
+using namespace verona::cpp;
+
+void test_acquire_cown_twice()
+{
+  Logging::cout() << "test_acquire_cown_twice()" << Logging::endl;
+
+  auto log = make_cown<int>(2);
+  auto alog = make_cown<int>(3);
+
+  when(log) << [=](auto) {
+    Logging::cout() << "log" << Logging::endl;
+  };
+
+  when(log, log) << [=](auto, auto) {
+    Logging::cout() << "log" << Logging::endl;
+  };
+
+  when(log, alog, log) << [=](auto, auto, auto) {
+    Logging::cout() << "log" << Logging::endl;
+  };
+}
+
+int main(int argc, char** argv)
+{
+  SystematicTestHarness harness(argc, argv);
+
+  harness.run(test_acquire_cown_twice);
+
+  return 0;
+}


### PR DESCRIPTION
Requesting the same cown multiple times in a when was creating a behaviour that wouldn't run. 

This would also block any subsequent happens after behaviour for the cowns invloved.

The DAG doesn't need multiple entries for the same behaviour on a cown and we need to also ensure the count down latch is correct.

When constructing the initial array of requests, they are sorted and uniqued.