### PR TITLE
Enable logging `std::string_view`

### DIFF
--- a/src/rt/debug/logging.h
+++ b/src/rt/debug/logging.h
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <snmalloc/snmalloc.h>
 #include <sstream>
+#include <string_view>
 #include <thread>
 
 namespace Logging
@@ -292,8 +293,6 @@ namespace Logging
     template<typename T>
     inline SysLog& inner_cons(const T& value)
     {
-      static_assert(sizeof(T) <= sizeof(size_t));
-
       if constexpr (systematic)
       {
         if (get_logging())
@@ -354,6 +353,11 @@ namespace Logging
     }
 
     inline SysLog& operator<<(const void* value)
+    {
+      return inner_cons(value);
+    }
+
+    inline SysLog& operator<<(std::string_view value)
     {
       return inner_cons(value);
     }


### PR DESCRIPTION
The motivation for this is to allow easier integration logging from rust, which uses ptr/len strings (like std::string_view)

See https://github.com/aDotInTheVoid/boxcars/commit/d54470655c3530a351280c51eeffb76be4399516 for an example of how this is used.

The `static_assert` has been present since 718baa857668a9bd1cb78d13e0074075bf1571a6. I removed it in `inner_cons`, but it's still present in `operator<<`, so no other large types may be logged.