### PR TITLE
Fix repeated cown

### DIFF
--- a/src/rt/sched/behaviourcore.h
+++ b/src/rt/sched/behaviourcore.h
@@ -313,10 +313,10 @@ namespace verona::rt
       for (size_t i = 0; i < body_count; i++)
         ec[i] = 1;
 
-      // Need to sort the cown requests across the co-scheduled collection of cowns
-      // We first construct an array that represents pairs of behaviour number and slot
-      // pointer.
-      // Note: Really want a dynamically sized stack allocation here.
+      // Need to sort the cown requests across the co-scheduled collection of
+      // cowns We first construct an array that represents pairs of behaviour
+      // number and slot pointer. Note: Really want a dynamically sized stack
+      // allocation here.
       StackArray<std::tuple<size_t, Slot*>> indexes(count);
       size_t idx = 0;
       for (size_t i = 0; i < body_count; i++)
@@ -334,8 +334,8 @@ namespace verona::rt
       // across the whole set of behaviours.  A consistent order is required to
       // avoid deadlock.
       // We sort first by cown, and then by behaviour number.
-      // These means overlaps will be in a sequence in the array in the correct order
-      // with respect to the order of the group of behaviours.
+      // These means overlaps will be in a sequence in the array in the correct
+      // order with respect to the order of the group of behaviours.
       auto compare = [](
                        const std::tuple<size_t, Slot*> i,
                        const std::tuple<size_t, Slot*> j) {
@@ -382,7 +382,8 @@ namespace verona::rt
           {
             Logging::cout() << "Duplicate cown: " << cown << " for behaviour "
                             << body << Logging::endl;
-            // We need to reduce the execution count by one, as we can't wait for ourselves.
+            // We need to reduce the execution count by one, as we can't wait
+            // for ourselves.
             ec[std::get<0>(indexes[i])]++;
 
             // We need to mark the slot as not having a cown associated to it.
@@ -424,7 +425,8 @@ namespace verona::rt
           }
           else
           {
-            Logging::cout() << "Acquiring reference count on cown: " << cown << Logging::endl;
+            Logging::cout()
+              << "Acquiring reference count on cown: " << cown << Logging::endl;
             // We didn't have any RCs passed in, so we need to acquire one.
             Cown::acquire(cown);
           }

--- a/src/rt/sched/behaviourcore.h
+++ b/src/rt/sched/behaviourcore.h
@@ -256,14 +256,13 @@ namespace verona::rt
     /**
      * @brief Schedule a behaviour for execution.
      *
-     * @tparam transfer - NoTransfer or YesTransfer - NoTransfer means
-     * any cowns that are scheduled will need a reference count added to them.
-     * YesTransfer means that the caller is transfering a reference count to
-     * each of the cowns, so the schedule should remove a count if it is not
-     * required.
-     * @param body  The behaviour to schedule.
+     * @param bodies  The behaviours to schedule.
+     *
+     * @param body_count The number of behaviours to schedule.
      *
      * @note
+     *
+     * *** Single behaviour scheduling ***
      *
      * To correctly implement the happens before order, we need to ensure that
      * one when cannot overtake another:
@@ -295,6 +294,66 @@ namespace verona::rt
      * on the cown. This means the first behaviour to access a cown will need to
      * perform an acquire. When the execution of a chain completes, then the
      * scheduler will release the RC.
+     *
+     * *** Extension to Many ***
+     *
+     * This code additional can schedule a group of behaviours atomically.
+     *
+     *   when (a) { B1 } + when (b) { B2 } + when (a, b) { B3 }
+     *
+     * This will cause the three behaviours to be scheduled in a single atomic
+     * step using the two phase commit.  This means that no other behaviours can
+     * access a between B1 and B3, and no other behaviours can access b between
+     * B2 and B3.
+     *
+     * This extension is implemented by building a mapping from each request
+     * to the sorted order of.  In this case that produces
+     *
+     *  0 -> 0, a
+     *  1 -> 1, b
+     *  2 -> 2, a
+     *  3 -> 2, b
+     *
+     * which gets sorted to
+     *
+     *  0 -> 0, a
+     *  1 -> 2, a
+     *  2 -> 1, b
+     *  3 -> 2, b
+     *
+     * We then link the (0,a) |-> (2,a), and enqueue the segment atomically onto
+     * cown a, and then link (1,b) |-> (2,b) and enqueue the segment atomically
+     * onto cown b.
+     *
+     * By enqueuing segments we ensure nothing can get in between the
+     * behaviours.
+     *
+     * *** Duplicate Cowns ***
+     *
+     * The final complication the code must deal with is duplicate cowns.
+     *
+     * when (a, a) { B1 }
+     *
+     * To handle this we need to detect the duplicate cowns, and mark the slot
+     * as not needing a successor.  This is done by setting the cown pointer to
+     * nullptr.
+     *
+     * Consider the following complex example
+     *
+     * when (a) { ... } + when (a,a) { ... } + when (a) { ... }
+     *
+     * This will produce the following mapping
+     *
+     * 0 -> 0, a
+     * 1 -> 1, a (0)
+     * 2 -> 1, a (1)
+     * 3 -> 2, a
+     *
+     * This is sorted already, so we can just link the segments
+     *
+     * (0,a) |-> (1, a (0)) |-> (2, a)
+     *
+     * and mark (a (1)) as not having a successor.
      */
     static void schedule_many(BehaviourCore** bodies, size_t body_count)
     {

--- a/test/func/dynamic-cownset/dynamic-cownset.cc
+++ b/test/func/dynamic-cownset/dynamic-cownset.cc
@@ -251,6 +251,22 @@ void test_move()
     [=](auto) { Logging::cout() << "log" << Logging::endl; };
 }
 
+void test_repeated_cown()
+{
+  Logging::cout() << "test_repeated_cown()" << Logging::endl;
+
+  auto log1 = make_cown<Body1>(1);
+
+  cown_ptr<Body1> carray[2];
+  carray[0] = log1;
+  carray[1] = log1;
+
+  cown_array<Body1> t1{carray, 2};
+
+  when(std::move(t1)) <<
+    [=](auto) { Logging::cout() << "log" << Logging::endl; };
+}
+
 int main(int argc, char** argv)
 {
   SystematicTestHarness harness(argc, argv);
@@ -271,6 +287,8 @@ int main(int argc, char** argv)
   harness.run(test_nest2);
 
   harness.run(test_move);
+
+  harness.run(test_repeated_cown);
 
   return 0;
 }

--- a/test/func/when-repeated-cown/repeat-cown.cc
+++ b/test/func/when-repeated-cown/repeat-cown.cc
@@ -13,21 +13,15 @@ void test_acquire_cown_twice()
   auto log = make_cown<int>(2);
   auto alog = make_cown<int>(3);
 
-  when(log) << [=](auto) {
-    Logging::cout() << "first log" << Logging::endl;
-  };
+  when(log) << [=](auto) { Logging::cout() << "first log" << Logging::endl; };
 
-  when(log, log) << [=](auto, auto) {
-    Logging::cout() << "second log" << Logging::endl;
-  };
+  when(log, log) <<
+    [=](auto, auto) { Logging::cout() << "second log" << Logging::endl; };
 
-  when(log, alog, log) << [=](auto, auto, auto) {
-    Logging::cout() << "third log" << Logging::endl;
-  };
+  when(log, alog, log) <<
+    [=](auto, auto, auto) { Logging::cout() << "third log" << Logging::endl; };
 
-  when(log) << [=](auto) {
-    Logging::cout() << "final log" << Logging::endl;
-  };
+  when(log) << [=](auto) { Logging::cout() << "final log" << Logging::endl; };
 }
 
 int main(int argc, char** argv)

--- a/test/func/when-repeated-cown/repeat-cown.cc
+++ b/test/func/when-repeated-cown/repeat-cown.cc
@@ -1,0 +1,40 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <cpp/when.h>
+#include <debug/harness.h>
+
+using namespace verona::cpp;
+
+void test_acquire_cown_twice()
+{
+  Logging::cout() << "test_acquire_cown_twice()" << Logging::endl;
+
+  auto log = make_cown<int>(2);
+  auto alog = make_cown<int>(3);
+
+  when(log) << [=](auto) {
+    Logging::cout() << "first log" << Logging::endl;
+  };
+
+  when(log, log) << [=](auto, auto) {
+    Logging::cout() << "second log" << Logging::endl;
+  };
+
+  when(log, alog, log) << [=](auto, auto, auto) {
+    Logging::cout() << "third log" << Logging::endl;
+  };
+
+  when(log) << [=](auto) {
+    Logging::cout() << "final log" << Logging::endl;
+  };
+}
+
+int main(int argc, char** argv)
+{
+  SystematicTestHarness harness(argc, argv);
+
+  harness.run(test_acquire_cown_twice);
+
+  return 0;
+}


### PR DESCRIPTION
The runtime did not correctly handle repeated cowns in a single when, and would cause the behaviour to never fire, and any subsequent behaviour would be blocked.

That is the following code:
```
when(a,a) { abort(); }
when(a) { abort(); }
```
would never reach abort.

This PR fixes this by reducing the execution count if there are duplicates, and setting the `cown` associated with the `Slot` to null so that we do not we can skip the slot in release (it will never get a successor).