### PR TITLE
Remove old variadic templates

### DIFF
--- a/src/rt/cpp/lambdabehaviour.h
+++ b/src/rt/cpp/lambdabehaviour.h
@@ -11,19 +11,19 @@ namespace verona::rt
   template<TransferOwnership transfer = NoTransfer, typename T>
   static void schedule_lambda(Cown* c, T&& f)
   {
-    Behaviour::schedule<T, transfer>(c, std::forward<T>(f));
+    Behaviour::schedule<transfer>(c, std::forward<T>(f));
   }
 
   template<TransferOwnership transfer = NoTransfer, typename T>
   static void schedule_lambda(size_t count, Cown** cowns, T&& f)
   {
-    Behaviour::schedule<T, transfer>(count, cowns, std::forward<T>(f));
+    Behaviour::schedule<transfer>(count, cowns, std::forward<T>(f));
   }
 
   template<TransferOwnership transfer = NoTransfer, typename T>
   static void schedule_lambda(size_t count, Request* requests, T&& f)
   {
-    Behaviour::schedule<T, transfer>(count, requests, std::forward<T>(f));
+    Behaviour::schedule<transfer>(count, requests, std::forward<T>(f));
   }
 
   template<typename T>

--- a/test/func/cown_weak_ref/cown_weak_ref.cc
+++ b/test/func/cown_weak_ref/cown_weak_ref.cc
@@ -93,7 +93,7 @@ struct Up
     {
       if (m->parent->acquire_strong_from_weak())
       {
-        Behaviour::schedule<Up, YesTransfer>(m->parent, m->parent);
+        schedule_lambda<YesTransfer>(m->parent, Up(m->parent));
       }
     }
   }
@@ -121,12 +121,12 @@ struct Down
 
     if (m->left != nullptr)
     {
-      Behaviour::schedule<Down>(m->left, m->left);
+      schedule_lambda(m->left, Down(m->left));
     }
 
     if (m->right != nullptr)
     {
-      Behaviour::schedule<Down>(m->right, m->right);
+      schedule_lambda(m->right, Down(m->right));
     }
   }
 };
@@ -135,8 +135,8 @@ void run_test()
 {
   auto t = make_tree(9, nullptr);
 
-  Behaviour::schedule<Down>(t, t);
-  Behaviour::schedule<Down, YesTransfer>(t, t);
+  schedule_lambda(t, Down(t));
+  schedule_lambda<YesTransfer>(t, Down(t));
 }
 
 int main(int argc, char** argv)

--- a/test/func/cowngc1/cowngc1.cc
+++ b/test/func/cowngc1/cowngc1.cc
@@ -257,7 +257,7 @@ struct Pong
     if (ccown->child != nullptr)
     {
       for (int n = 0; n < 20; n++)
-        Behaviour::schedule<Pong>(ccown->child, ccown->child);
+        schedule_lambda(ccown->child, Pong(ccown->child));
     }
   }
 };
@@ -273,31 +273,31 @@ struct Ping
     if (rcown->forward > 0)
     {
       // Forward Ping to next RCown.
-      Behaviour::schedule<Ping>(rcown->next, rcown->next, rand);
+      schedule_lambda(rcown->next, Ping(rcown->next, rand));
 
       // Send Pongs to child CCowns.
       for (uint64_t i = 0; i < others_count; i++)
       {
         if (rcown->array[i] != nullptr)
-          Behaviour::schedule<Pong>(rcown->array[i], rcown->array[i]);
+          schedule_lambda(rcown->array[i], Pong(rcown->array[i]));
       }
       if (rcown->otrace != nullptr && rcown->otrace->cown != nullptr)
-        Behaviour::schedule<Pong>(rcown->otrace->cown, rcown->otrace->cown);
+        schedule_lambda(rcown->otrace->cown, Pong(rcown->otrace->cown));
       if (rcown->oarena != nullptr && rcown->oarena->cown != nullptr)
-        Behaviour::schedule<Pong>(rcown->oarena->cown, rcown->oarena->cown);
+        schedule_lambda(rcown->oarena->cown, Pong(rcown->oarena->cown));
       if (rcown->imm1 != nullptr)
       {
         auto c1 = rcown->imm1->cown;
         auto c2 = rcown->imm1->f1->cown;
-        Behaviour::schedule<Pong>(c1, c1);
-        Behaviour::schedule<Pong>(c2, c2);
+        schedule_lambda(c1, Pong(c1));
+        schedule_lambda(c2, Pong(c2));
       }
       if (rcown->imm2 != nullptr)
       {
         auto c1 = rcown->imm2->cown;
         auto c2 = rcown->imm2->f1->cown;
-        Behaviour::schedule<Pong>(c1, c1);
-        Behaviour::schedule<Pong>(c2, c2);
+        schedule_lambda(c1, Pong(c1));
+        schedule_lambda(c2, Pong(c2));
       }
 
       // Randomly introduce a pointer nulling operations. We don't want to do
@@ -381,7 +381,7 @@ void test_cown_gc(
   rcown_first = nullptr;
   auto a = new RCown(ring_size, forward_count);
   rand->seed(h->current_seed());
-  Behaviour::schedule<Ping>(a, a, rand);
+  schedule_lambda(a, Ping(a, rand));
 }
 
 void test_cown_gc_before_sched()

--- a/test/func/cowngc4/cowngc4.cc
+++ b/test/func/cowngc4/cowngc4.cc
@@ -279,7 +279,7 @@ struct Pong
     if (ccown->child != nullptr)
     {
       for (int n = 0; n < 20; n++)
-        Behaviour::schedule<Pong>(ccown->child, ccown->child);
+        schedule_lambda(ccown->child, Pong(ccown->child));
     }
   }
 };
@@ -298,7 +298,7 @@ struct Ping
     if (rcown->forward > 0)
     {
       // Forward Ping to next RCown.
-      Behaviour::schedule<Ping<region_type>>(rcown->next, rcown->next, rand);
+      schedule_lambda(rcown->next, Ping<region_type>(rcown->next, rand));
 
       // Send Pongs to child CCowns.
       if (
@@ -306,25 +306,25 @@ struct Ping
         rcown->reg_with_graph->f->f->cown != nullptr)
       {
         auto c = rcown->reg_with_graph->f->f->cown;
-        Behaviour::schedule<Pong>(c, c);
+        schedule_lambda(c, Pong(c));
       }
       if (
         rcown->reg_with_sub != nullptr &&
         rcown->reg_with_sub->f1->f2->f2->cown != nullptr)
       {
         auto c = rcown->reg_with_sub->f1->f2->f2->cown;
-        Behaviour::schedule<Pong>(c, c);
+        schedule_lambda(c, Pong(c));
       }
       if (rcown->reg_with_imm != nullptr)
       {
         auto c1 = rcown->reg_with_imm->imm1->cown;
         auto c2 = rcown->reg_with_imm->imm1->f1->cown;
-        Behaviour::schedule<Pong>(c1, c1);
-        Behaviour::schedule<Pong>(c2, c2);
+        schedule_lambda(c1, Pong(c1));
+        schedule_lambda(c2, Pong(c2));
         c1 = rcown->reg_with_imm->imm2->cown;
         c2 = rcown->reg_with_imm->imm2->f1->cown;
-        Behaviour::schedule<Pong>(c1, c1);
-        Behaviour::schedule<Pong>(c2, c2);
+        schedule_lambda(c1, Pong(c1));
+        schedule_lambda(c2, Pong(c2));
       }
 
       // Randomly introduce a few leaks. We don't want to do this for every
@@ -396,7 +396,7 @@ void test_cown_gc(
   rcown_first = nullptr;
   auto a = new RCown<region_type>(ring_size, forward_count);
   rand->seed(h->current_seed());
-  Behaviour::schedule<Ping<region_type>>(a, a, rand);
+  schedule_lambda(a, Ping<region_type>(a, rand));
 }
 
 int main(int argc, char** argv)

--- a/test/func/diningphilosophers/diningphil.cc
+++ b/test/func/diningphilosophers/diningphil.cc
@@ -36,7 +36,7 @@ struct KeepAlive
   KeepAlive()
   {
     c = new Fork(999);
-    Behaviour::schedule<Ping>(c);
+    schedule_lambda(c, Ping());
   }
 
   void trace(ObjectStack& fields) const
@@ -46,7 +46,7 @@ struct KeepAlive
 
   void operator()()
   {
-    Behaviour::schedule<Ping, YesTransfer>(c);
+    schedule_lambda<YesTransfer>(c, Ping());
   }
 };
 
@@ -98,7 +98,7 @@ struct Eat
       ((Fork*)f)->uses++;
     }
 
-    Behaviour::schedule<Ponder>(eater, eater);
+    schedule_lambda(eater, Ponder(eater));
   }
 
   Eat(Philosopher* p_) : eater(p_)
@@ -126,9 +126,9 @@ void eat_send(Philosopher* p)
   }
 
   p->to_eat--;
-  Behaviour::schedule<Eat>(p->forks.size(), p->forks.data(), p);
+  schedule_lambda(p->forks.size(), p->forks.data(), Eat(p));
 
-  Behaviour::schedule<KeepAlive>(p->forks[0]);
+  schedule_lambda(p->forks[0], KeepAlive());
 }
 
 void test_dining(
@@ -167,7 +167,7 @@ void test_dining(
     }
 
     auto p = new Philosopher(i, my_forks, hunger);
-    Behaviour::schedule<Ponder>(p, p);
+    schedule_lambda(p, Ponder(p));
     Logging::cout() << "Philosopher " << i << " " << p << std::endl;
     for (size_t j = 0; j < fork_count; j++)
     {

--- a/test/func/ext_ref_freeze/ext_ref_freeze.cc
+++ b/test/func/ext_ref_freeze/ext_ref_freeze.cc
@@ -86,14 +86,14 @@ struct Loop
         }
         freeze(a->r);
         state = REUSE;
-        Behaviour::schedule<Loop>(a, a);
+        schedule_lambda(a, Loop(a));
         return;
       }
       case REUSE:
       {
         state = EXIT;
-        Behaviour::schedule<Ping>(a->r->f1->b);
-        Behaviour::schedule<Loop>(a, a);
+        schedule_lambda(a->r->f1->b, Ping());
+        schedule_lambda(a, Loop(a));
         return;
       }
       case EXIT:
@@ -124,7 +124,7 @@ void run_test()
 {
   auto& alloc = ThreadAlloc::get();
   auto a = new A;
-  Behaviour::schedule<Loop>(a, a);
+  schedule_lambda(a, Loop(a));
   Cown::release(alloc, a);
 }
 

--- a/test/func/noticeboard/noticeboard_basic.h
+++ b/test/func/noticeboard/noticeboard_basic.h
@@ -174,9 +174,9 @@ namespace noticeboard_basic
 
     Logging::cout() << "Peeker " << peeker << std::endl;
 
-    Behaviour::schedule<ToPeek>(peeker, peeker);
-    Behaviour::schedule<UpdateDB>(peeker->db, peeker->db);
-    Behaviour::schedule<Ping>(alive, alive);
+    schedule_lambda(peeker, ToPeek(peeker));
+    schedule_lambda(peeker->db, UpdateDB(peeker->db));
+    schedule_lambda(alive, Ping(alive));
 
     Cown::release(alloc, alive);
     Cown::release(alloc, peeker);

--- a/test/func/noticeboard/noticeboard_primitive_weak.h
+++ b/test/func/noticeboard/noticeboard_primitive_weak.h
@@ -84,7 +84,7 @@ namespace noticeboard_primitive_weak
     g_writer = new Writer(x_0, x_1);
     g_reader = new Reader(&g_writer->box_0, &g_writer->box_1);
 
-    Behaviour::schedule<ReaderLoop>(g_reader, g_reader);
-    Behaviour::schedule<WriterLoop>(g_writer, g_writer);
+    schedule_lambda(g_reader, ReaderLoop(g_reader));
+    schedule_lambda(g_writer, WriterLoop(g_writer));
   }
 }

--- a/test/func/noticeboard/noticeboard_weak.h
+++ b/test/func/noticeboard/noticeboard_weak.h
@@ -100,7 +100,7 @@ namespace noticeboard_weak
     g_writer = new Writer(c_0, c_1);
     g_reader = new Reader(&g_writer->box_0, &g_writer->box_1);
 
-    Behaviour::schedule<ReaderLoop>(g_reader, g_reader);
-    Behaviour::schedule<WriterLoop>(g_writer, g_writer);
+    schedule_lambda(g_reader, ReaderLoop(g_reader));
+    schedule_lambda(g_writer, WriterLoop(g_writer));
   }
 }

--- a/test/perf/backpressure1/backpressure1.cc
+++ b/test/perf/backpressure1/backpressure1.cc
@@ -84,12 +84,12 @@ struct Forward
     if (proxy != proxy_chain.back())
     {
       auto* next = proxy_chain[proxy->index + 1];
-      Behaviour::schedule<Forward>(next, next);
+      schedule_lambda(next, Forward(next));
       return;
     }
 
-    Behaviour::schedule<Receive>(
-      receiver_set.size(), (Cown**)receiver_set.data());
+    schedule_lambda(
+      receiver_set.size(), (Cown**)receiver_set.data(), Receive());
   }
 };
 
@@ -124,13 +124,13 @@ struct Send
   void operator()()
   {
     if (proxy_chain.size() > 0)
-      Behaviour::schedule<Forward>(proxy_chain[0], proxy_chain[0]);
+      schedule_lambda(proxy_chain[0], Forward(proxy_chain[0]));
     else
-      Behaviour::schedule<Receive>(
-        receiver_set.size(), (Cown**)receiver_set.data());
+      schedule_lambda(
+        receiver_set.size(), (Cown**)receiver_set.data(), Receive());
 
     if ((Sender::clk::now() - s->start) < s->duration)
-      Behaviour::schedule<Send>(s, s);
+      schedule_lambda(s, Send(s));
   }
 };
 
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
       }
 
       auto* s = new (alloc) Sender(std::chrono::milliseconds(duration));
-      Behaviour::schedule<Send, YesTransfer>(s, s);
+      schedule_lambda<YesTransfer>(s, Send(s));
     }
 
     if (proxy_chain.size() > 0)

--- a/test/perf/backpressure2/backpressure2.cc
+++ b/test/perf/backpressure2/backpressure2.cc
@@ -37,9 +37,18 @@ struct Receive
   : receivers(receivers_), receiver_count(receiver_count_)
   {}
 
+  Receive(Receive&& o) noexcept
+  {
+    receiver_count = o.receiver_count;
+    receivers = o.receivers;
+
+    o.receivers = nullptr;
+  }
+
   ~Receive()
   {
-    ThreadAlloc::get().dealloc(receivers, receiver_count * sizeof(Receiver*));
+    if (receivers)
+      ThreadAlloc::get().dealloc(receivers, receiver_count * sizeof(Receiver*));
   }
 
   void trace(ObjectStack& st) const

--- a/test/perf/backpressure2/backpressure2.cc
+++ b/test/perf/backpressure2/backpressure2.cc
@@ -111,11 +111,11 @@ struct Send
         i++;
     }
 
-    Behaviour::schedule<Receive>(
-      receiver_count, (Cown**)receivers, receivers, receiver_count);
+    schedule_lambda(
+      receiver_count, (Cown**)receivers, Receive(receivers, receiver_count));
 
     if ((timer::now() - s->start) < s->duration)
-      Behaviour::schedule<Send>(s, s);
+      schedule_lambda(s, Send(s));
   }
 };
 
@@ -154,7 +154,7 @@ int main(int argc, char** argv)
 
     auto* s = new (alloc) Sender(
       std::chrono::milliseconds(duration), receiver_set, seed, rng.next());
-    Behaviour::schedule<Send, YesTransfer>(s, s);
+    schedule_lambda<YesTransfer>(s, Send(s));
   }
 
   for (auto* r : receiver_set)

--- a/test/perf/backpressure3/backpressure3.cc
+++ b/test/perf/backpressure3/backpressure3.cc
@@ -57,7 +57,7 @@ struct Receive
       auto** cowns = (Cown**)alloc.alloc<2 * sizeof(Cown*)>();
       cowns[0] = (Cown*)r;
       cowns[1] = (Cown*)s;
-      Behaviour::schedule<Receive>(2, cowns, r, s);
+      schedule_lambda(2, cowns, Receive(r, s));
       alloc.dealloc<2 * sizeof(Cown*)>(cowns);
     }
     else
@@ -103,10 +103,10 @@ struct Send
 
   void operator()()
   {
-    Behaviour::schedule<Receive>(s->receiver, s->receiver);
+    schedule_lambda(s->receiver, Receive(s->receiver));
 
     if ((timer::now() - s->start) < s->duration)
-      Behaviour::schedule<Send>(s, s);
+      schedule_lambda(s, Send(s));
     else
     {
       // Break cycle between sender and receiver.
@@ -149,7 +149,7 @@ int main(int argc, char** argv)
   }
 
   for (auto* s : sender_set)
-    Behaviour::schedule<Send, NoTransfer>(s, s);
+    schedule_lambda<NoTransfer>(s, Send(s));
   Cown::release(alloc, receiver);
 
   sched.run();


### PR DESCRIPTION
This PR removes the need for variadic templates for Behaviour. That was a remainder of the old way to schedule behaviours.