### PR TITLE
Backpressure tests didn't enable crash logging

### DIFF
--- a/src/rt/debug/harness.h
+++ b/src/rt/debug/harness.h
@@ -134,8 +134,8 @@ public:
 #endif
   }
 
-  template<typename... Args>
-  void run(void f(Args...), Args... args)
+  template<typename F, typename... Args>
+  void run(F&& f, Args... args)
   {
     for (seed = seed_lower; seed < seed_upper; seed++)
     {

--- a/test/perf/backpressure1/backpressure1.cc
+++ b/test/perf/backpressure1/backpressure1.cc
@@ -147,6 +147,10 @@ int main(int argc, char** argv)
                  << ", receivers: " << receivers << ", duration: " << duration
                  << "ms" << std::endl;
 
+#if defined(USE_FLIGHT_RECORDER) || defined(CI_BUILD)
+  Logging::enable_crash_logging();
+#endif
+
 #ifdef USE_SYSTEMATIC_TESTING
   Logging::enable_logging();
   Systematic::set_seed(seed);

--- a/test/perf/backpressure1/backpressure1.cc
+++ b/test/perf/backpressure1/backpressure1.cc
@@ -17,6 +17,7 @@
 #include "debug/log.h"
 #include "test/opt.h"
 #include "verona.h"
+#include "debug/harness.h"
 
 #include <chrono>
 
@@ -136,79 +137,60 @@ struct Send
 
 int main(int argc, char** argv)
 {
-  opt::Opt opt(argc, argv);
-  auto seed = opt.is<size_t>("--seed", 5489);
-  auto cores = opt.is<size_t>("--cores", 4);
-  auto senders = opt.is<size_t>("--senders", 100);
-  auto receivers = opt.is<size_t>("--receivers", 1);
-  auto proxies = opt.is<size_t>("--proxies", 0);
-  auto duration = opt.is<size_t>("--duration", 10'000);
-  logger::cout() << "cores: " << cores << ", senders: " << senders
-                 << ", receivers: " << receivers << ", duration: " << duration
-                 << "ms" << std::endl;
+  SystematicTestHarness harness(argc, argv);
 
-#if defined(USE_FLIGHT_RECORDER) || defined(CI_BUILD)
-  Logging::enable_crash_logging();
-#endif
+  auto senders = harness.opt.is<size_t>("--senders", 100);
+  auto receivers = harness.opt.is<size_t>("--receivers", 1);
+  auto proxies = harness.opt.is<size_t>("--proxies", 0);
+  auto duration = harness.opt.is<size_t>("--duration", 10'000);
 
-#ifdef USE_SYSTEMATIC_TESTING
-  Logging::enable_logging();
-  Systematic::set_seed(seed);
-#else
-  UNUSED(seed);
-#endif
-  Scheduler::set_detect_leaks(true);
-  auto& sched = Scheduler::get();
-  sched.set_fair(true);
-  sched.init(cores);
+  harness.run([senders, receivers, proxies, duration, &harness] () {
+    Alloc& alloc = ThreadAlloc::get();
 
-  Alloc& alloc = ThreadAlloc::get();
+    for (size_t r = 0; r < receivers; r++)
+      receiver_set.push_back(new (alloc) Receiver);
 
-  for (size_t r = 0; r < receivers; r++)
-    receiver_set.push_back(new (alloc) Receiver);
+    for (size_t p = 0; p < proxies; p++)
+      proxy_chain.push_back(new (alloc) Proxy(p));
 
-  for (size_t p = 0; p < proxies; p++)
-    proxy_chain.push_back(new (alloc) Proxy(p));
+    auto e = make_cown<int>();
+    when(e) << [](auto) {
+      Logging::cout() << "Add external event source" << std::endl;
+      Scheduler::add_external_event_source();
+    };
 
-  auto e = make_cown<int>();
-  when(e) << [](auto) {
-    Logging::cout() << "Add external event source" << std::endl;
-    Scheduler::add_external_event_source();
-  };
+    harness.external_thread([=](){
+      Alloc& alloc = ThreadAlloc::get();
+      for (size_t i = 0; i < senders; i++)
+      {
+        if (proxy_chain.size() > 0)
+        {
+          Cown::acquire(proxy_chain[0]);
+        }
+        else
+        {
+          for (auto* r : receiver_set)
+            Cown::acquire(r);
+        }
 
-  auto thr = std::thread([=, &alloc] {
-    for (size_t i = 0; i < senders; i++)
-    {
+        auto* s = new (alloc) Sender(std::chrono::milliseconds(duration));
+        schedule_lambda<YesTransfer>(s, Send(s));
+      }
+
       if (proxy_chain.size() > 0)
       {
-        Cown::acquire(proxy_chain[0]);
+        Cown::release(alloc, proxy_chain[0]);
       }
       else
       {
         for (auto* r : receiver_set)
-          Cown::acquire(r);
+          Cown::release(alloc, r);
       }
 
-      auto* s = new (alloc) Sender(std::chrono::milliseconds(duration));
-      schedule_lambda<YesTransfer>(s, Send(s));
-    }
-
-    if (proxy_chain.size() > 0)
-    {
-      Cown::release(alloc, proxy_chain[0]);
-    }
-    else
-    {
-      for (auto* r : receiver_set)
-        Cown::release(alloc, r);
-    }
-
-    when(e) << [](auto) {
-      Logging::cout() << "Remove external event source" << std::endl;
-      Scheduler::remove_external_event_source();
-    };
+      when(e) << [](auto) {
+        Logging::cout() << "Remove external event source" << std::endl;
+        Scheduler::remove_external_event_source();
+      };
+    });
   });
-
-  sched.run();
-  thr.join();
 }

--- a/test/perf/backpressure1/backpressure1.cc
+++ b/test/perf/backpressure1/backpressure1.cc
@@ -14,10 +14,10 @@
  */
 
 #include "cpp/when.h"
+#include "debug/harness.h"
 #include "debug/log.h"
 #include "test/opt.h"
 #include "verona.h"
-#include "debug/harness.h"
 
 #include <chrono>
 
@@ -144,7 +144,7 @@ int main(int argc, char** argv)
   auto proxies = harness.opt.is<size_t>("--proxies", 0);
   auto duration = harness.opt.is<size_t>("--duration", 10'000);
 
-  harness.run([senders, receivers, proxies, duration, &harness] () {
+  harness.run([senders, receivers, proxies, duration, &harness]() {
     Alloc& alloc = ThreadAlloc::get();
 
     for (size_t r = 0; r < receivers; r++)
@@ -159,7 +159,7 @@ int main(int argc, char** argv)
       Scheduler::add_external_event_source();
     };
 
-    harness.external_thread([=](){
+    harness.external_thread([=]() {
       Alloc& alloc = ThreadAlloc::get();
       for (size_t i = 0; i < senders; i++)
       {

--- a/test/perf/backpressure2/backpressure2.cc
+++ b/test/perf/backpressure2/backpressure2.cc
@@ -140,6 +140,10 @@ int main(int argc, char** argv)
                  << ", receivers: " << receivers << ", duration: " << duration
                  << "ms" << std::endl;
 
+#if defined(USE_FLIGHT_RECORDER) || defined(CI_BUILD)
+  Logging::enable_crash_logging();
+#endif
+
 #ifdef USE_SYSTEMATIC_TESTING
   Logging::enable_logging();
   Systematic::set_seed(seed);

--- a/test/perf/backpressure3/backpressure3.cc
+++ b/test/perf/backpressure3/backpressure3.cc
@@ -128,6 +128,10 @@ int main(int argc, char** argv)
   logger::cout() << "cores: " << cores << ", senders: " << senders
                  << ", duration: " << duration.count() << "ms" << std::endl;
 
+#if defined(USE_FLIGHT_RECORDER) || defined(CI_BUILD)
+  Logging::enable_crash_logging();
+#endif
+
 #ifdef USE_SYSTEMATIC_TESTING
   Logging::enable_logging();
   Systematic::set_seed(seed);


### PR DESCRIPTION
The failure in #14 is hard to diagnose.  This change should make that easier by enabling crash logging for this test.  Most tests get this automatically from the harness, but this is not using the standard harness as it is simulating external work. 