### PR TITLE
Remove needless template parameter from Behaviour::make.

### DIFF
--- a/src/rt/cpp/lambdabehaviour.h
+++ b/src/rt/cpp/lambdabehaviour.h
@@ -8,28 +8,28 @@
 
 namespace verona::rt
 {
-  template<TransferOwnership transfer = NoTransfer, typename T>
-  static void schedule_lambda(Cown* c, T&& f)
+  template<TransferOwnership transfer = NoTransfer, typename Be>
+  static void schedule_lambda(Cown* c, Be&& f)
   {
-    Behaviour::schedule<transfer>(c, std::forward<T>(f));
+    Behaviour::schedule<transfer>(c, std::forward<Be>(f));
   }
 
-  template<TransferOwnership transfer = NoTransfer, typename T>
-  static void schedule_lambda(size_t count, Cown** cowns, T&& f)
+  template<TransferOwnership transfer = NoTransfer, typename Be>
+  static void schedule_lambda(size_t count, Cown** cowns, Be&& f)
   {
-    Behaviour::schedule<transfer>(count, cowns, std::forward<T>(f));
+    Behaviour::schedule<transfer>(count, cowns, std::forward<Be>(f));
   }
 
-  template<typename T>
-  static void schedule_lambda(size_t count, Request* requests, T&& f)
+  template<typename Be>
+  static void schedule_lambda(size_t count, Request* requests, Be&& f)
   {
-    Behaviour::schedule(count, requests, std::forward<T>(f));
+    Behaviour::schedule(count, requests, std::forward<Be>(f));
   }
 
-  template<typename T>
-  static void schedule_lambda(T&& f)
+  template<typename Be>
+  static void schedule_lambda(Be&& f)
   {
-    auto w = Closure::make([f = std::forward<T>(f)](Work* w) mutable {
+    auto w = Closure::make([f = std::forward<Be>(f)](Work* w) mutable {
       f();
       return true;
     });
@@ -38,11 +38,11 @@ namespace verona::rt
 
   // TODO super minimal version initially, just to get the tests working.
   // Should be expanded to cover multiple cowns.
-  template<typename T>
-  inline Notification* make_notification(Cown* cown, T&& f)
+  template<typename Be>
+  inline Notification* make_notification(Cown* cown, Be&& f)
   {
     Request requests[] = {Request::write(cown)};
-    return Notification::make<T>(1, requests, std::forward<T>(f));
+    return Notification::make<Be>(1, requests, std::forward<Be>(f));
   }
 
 } // namespace verona::rt

--- a/src/rt/sched/behaviour.h
+++ b/src/rt/sched/behaviour.h
@@ -41,12 +41,12 @@ namespace verona::rt
       return rerun;
     }
 
-    template<typename Be, typename T>
-    static Behaviour* make(size_t count, T&& f)
+    template<typename Be>
+    static Behaviour* make(size_t count, Be&& f)
     {
       auto behaviour_core = BehaviourCore::make(count, invoke<Be>, sizeof(Be));
 
-      new (behaviour_core->get_body()) Be(std::forward<T>(f));
+      new (behaviour_core->get_body()) Be(std::forward<Be>(f));
 
       // These assertions are basically checking that we won't break any
       // alignment assumptions on Be.  If we add some actual alignment, then

--- a/src/rt/sched/behaviour.h
+++ b/src/rt/sched/behaviour.h
@@ -63,8 +63,8 @@ namespace verona::rt
       schedule<transfer, T>(1, &cown, std::forward<T>(f));
     }
 
-    template<TransferOwnership transfer = NoTransfer, class T>
-    static void schedule(size_t count, Cown** cowns, T&& f)
+    template<TransferOwnership transfer = NoTransfer, class Be>
+    static void schedule(size_t count, Cown** cowns, Be&& f)
     {
       // TODO Remove vector allocation here.  This is a temporary fix to
       // as we transition to using Request through the code base.
@@ -80,7 +80,7 @@ namespace verona::rt
         }
       }
 
-      schedule<T>(count, requests, std::forward<T>(f));
+      schedule<Be>(count, requests, std::forward<Be>(f));
 
       alloc.dealloc(requests);
     }
@@ -89,11 +89,11 @@ namespace verona::rt
      * Prepare a multimessage
      **/
 
-    template<typename T>
+    template<typename Be>
     static Behaviour*
-    prepare_to_schedule(size_t count, Request* requests, T&& f)
+    prepare_to_schedule(size_t count, Request* requests, Be&& f)
     {
-      auto body = Behaviour::make<T>(count, std::forward<T>(f));
+      auto body = Behaviour::make<Be>(count, std::forward<Be>(f));
 
       auto* slots = body->get_slots();
       for (size_t i = 0; i < count; i++)
@@ -106,13 +106,14 @@ namespace verona::rt
       return body;
     }
 
-    template<class T>
-    static void schedule(size_t count, Request* requests, T&& f)
+    template<class Be>
+    static void schedule(size_t count, Request* requests, Be&& f)
     {
-      Logging::cout() << "Schedule behaviour of type: " << typeid(T).name()
+      Logging::cout() << "Schedule behaviour of type: " << typeid(Be).name()
                       << Logging::endl;
 
-      auto* body = prepare_to_schedule<T>(count, requests, std::forward<T>(f));
+      auto* body =
+        prepare_to_schedule<Be>(count, requests, std::forward<Be>(f));
 
       BehaviourCore* arr[] = {body};
 


### PR DESCRIPTION
This template is only ever instantiated once (in `prepare_to_schedule`), and both of the parameters are the same. I don't think it'd be correct for them to be different.

I found this while trying to understand the how lambda's are stored, and was confused by what was going on here until I realized the both `T` and `Be` where the same.