### PR TITLE
Work Stealing

### DIFF
--- a/src/rt/ds/wrapindex.h
+++ b/src/rt/ds/wrapindex.h
@@ -20,6 +20,16 @@ public:
     return index;
   }
 
+  size_t operator--(int)
+  {
+    auto result = index;
+    if (result == 0)
+      index = N - 1;
+    else
+      index--;
+    return result;
+  }
+
   operator size_t() const
   {
     return index;

--- a/src/rt/ds/wrapindex.h
+++ b/src/rt/ds/wrapindex.h
@@ -1,0 +1,27 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <cstddef>
+
+// WrapIndex is a simple class that wraps around an index.
+template<size_t N>
+class WrapIndex
+{
+  size_t index;
+
+public:
+  WrapIndex() : index(0) {}
+
+  // Returns the next index and wraps around.
+  size_t operator++()
+  {
+    index = (index + 1) % N;
+    return index;
+  }
+
+  operator size_t() const
+  {
+    return index;
+  }
+};

--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -5,6 +5,7 @@
 #include "mpmcq.h"
 #include "schedulerstats.h"
 #include "work.h"
+#include "workstealingqueue.h"
 
 #include <atomic>
 #include <snmalloc/snmalloc.h>
@@ -15,7 +16,7 @@ namespace verona::rt
   {
   public:
     size_t affinity = 0;
-    MPMCQ<Work> q;
+    WorkStealingQueue<4> q;
     std::atomic<Core*> next{nullptr};
     std::atomic<bool> should_steal_for_fairness{false};
 

--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -44,7 +44,7 @@ namespace verona::rt
     }
 
   public:
-    Core() : q{create_token_work(this)} {}
+    Core() : q{} {}
 
     ~Core() {}
   };

--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -18,7 +18,20 @@ namespace verona::rt
     size_t affinity = 0;
     WorkStealingQueue<4> q;
     std::atomic<Core*> next{nullptr};
-    std::atomic<bool> should_steal_for_fairness{false};
+
+    std::atomic<bool> should_steal_for_fairness{true};
+
+    /**
+     * @brief Create a token work object.  It is affinitised to the `this`
+     * core, and marks that stealing is required, for fairness.
+     */
+    Work* token_work{Closure::make([this](Work* w) {
+      this->should_steal_for_fairness = true;
+      // The token work is only deallocated during the destruction of the core.
+      // The destructor will run the token work, and return true, so that the
+      // closure code will run destructors and deallocate the memory.
+      return this->token_work == nullptr;
+    })};
 
     /// Progress and synchronization between the threads.
     //  These counters represent progress on a CPU core, not necessarily on
@@ -29,24 +42,14 @@ namespace verona::rt
 
     SchedulerStats stats;
 
-    /**
-     * @brief Create a token work object.  It is affinitised to the `home`
-     * core, and marks that stealing is required, for fairness. Once completed
-     * it reschedules itself on the home core.
-     */
-    Work* create_token_work(Core* home)
-    {
-      auto w = Closure::make([home](Work* w) {
-        home->should_steal_for_fairness = true;
-        home->q.enqueue(w);
-        return false;
-      });
-      return w;
-    }
-
   public:
     Core() : q{} {}
 
-    ~Core() {}
+    ~Core()
+    {
+      auto tw = token_work;
+      token_work = nullptr;
+      tw->run();
+    }
   };
 }

--- a/src/rt/sched/mpmcq.h
+++ b/src/rt/sched/mpmcq.h
@@ -34,8 +34,8 @@ namespace verona::rt
 
     std::atomic<NextPtr*> back{&front};
 
-    // Multi-threaded end of the "queue" requires ABA protection.
-    // Used for work stealing and posting new work from another thread.
+    // Multi-threaded end of the "queue".
+    // Used for work stealing and dequeue individual items.
     NextPtr front{nullptr};
 
     // Common function that is used to make the queue appear empty to any other
@@ -108,7 +108,7 @@ namespace verona::rt
 
       Systematic::yield();
 
-      auto b = back.exchange(ls.end, std::memory_order_seq_cst);
+      auto b = back.exchange(ls.end, std::memory_order_acq_rel);
 
       Systematic::yield();
 
@@ -202,7 +202,7 @@ namespace verona::rt
     {
       Systematic::yield();
 
-      return back.load(std::memory_order_acquire) == &front;
+      return back.load(std::memory_order_relaxed) == &front;
     }
 
     ~MPMCQ()

--- a/src/rt/sched/mpmcq.h
+++ b/src/rt/sched/mpmcq.h
@@ -7,66 +7,92 @@
 namespace verona::rt
 {
   /**
-   * Multiple Producer Multiple Consumer Queue.
+   * Multiple Producer Multiple Consumer Queue with steal all
    *
    * This queue forms the primary scheduler queue for each thread to
-   * schedule cowns.
+   * schedule work.
    *
    * The queue has two ends.
    *
    *   - the back end can be used by multiple thread using
    *     `enqueue` to add elements to the queue in a FIFO way wrt to `dequeue`.
-   *   - the front end can be used by multiple threads to `dequeue` elements
-   *     and `enqueue_front` elements. `enqueue_front` behaves in a LIFO way wrt
-   *     to `dequeue`.
+   *   - the front end can be used by multiple threads to `dequeue` and
+   * `dequeue_all` elements.  It is possible for dequeue to not see elements
+   * added by enqueue and spuriously return nullptr.
+   *
+   * The empty representation of the queue has the back pointing at the front.
+   * So that moving from empty to non-empty will not require branching.
    *
    * The queue uses an intrusive list in the elements of the queue.  (For
-   * Verona this is the Cowns). To make this memory safe and ABA safe we use
-   * two mechanisms.
-   *
-   *   - ABA protection from snmalloc - this will use LL/SC or Double-word
-   *     compare and swap.  This ensures that the same element can be added
-   *     to the queue multiple times without leading to ABA issues.
-   *   - Memory safety, the underlying elements of the queue my also be
-   *     deallocated however, if this occurs, then we could potentially access
-   *     decommitted memory with the optimistic concurrency. To protect against
-   *     this we use an epoch mechanism, that is, elements may only
-   *     deallocated, if sufficient epochs have passed since it was last in
-   *     the queue.
-   *
-   * Using two mechanisms means that we can have intrusive `next` fields,
-   * which gives zero allocation scheduling, but don't have to wait for the
-   * epoch to advance to reschedule.
-   *
-   * The queue also has a notion of a token. This is used to determine once
-   * the queue has been flushed through.  The client can check if the value
-   * popped is a token.  This is used to monitor how quickly this queue is
-   * completed, and then can be used for fairness scheduling.
-   *
-   * The queue doesn't know which work elements are the token, but the non-empty
-   * nature needs it to exist otherwise, we can't reach a quicent state.
+   * Verona this is the Work items).
    */
   template<class T>
   class MPMCQ
   {
   private:
-    friend T;
-    static constexpr uintptr_t BIT = 1;
-    // Multi-threaded enqueue end of the "queue"
-    // modified using exchange.
-    std::atomic<T*> back;
+    using NextPtr = std::atomic<T*>;
+
+    std::atomic<NextPtr*> back{&front};
+
     // Multi-threaded end of the "queue" requires ABA protection.
     // Used for work stealing and posting new work from another thread.
-    snmalloc::ABA<T> front;
+    NextPtr front{nullptr};
+
+    // Common function that is used to make the queue appear empty to any other
+    // dequeue or dequeue_all operations.
+    T* acquire_front()
+    {
+      Systematic::yield();
+
+      // Nothing in the queue
+      if (front.load(std::memory_order_relaxed) == nullptr)
+      {
+        return nullptr;
+      }
+
+      Systematic::yield();
+
+      // Remove head element.  This is like locking the queue for other
+      // removals.
+      return front.exchange(nullptr, std::memory_order_acquire);
+    }
 
   public:
-    explicit MPMCQ(T* token)
+    struct Segment
     {
-      assert(token);
-      token->next_in_queue = nullptr;
-      back = token;
-      front.init(token);
-    }
+      T* start;
+      NextPtr* end;
+
+      Segment(T* s, NextPtr* e) : start(s), end(e) {}
+
+      // In place removes the first element from the segment.
+      // Returns nullptr if the first element cannot be removed.
+      // This can be for three reasons:
+      // 1. The segment is empty
+      // 2. The segment has a single element.
+      // 3. The segment has link has not been completed.
+      T* take_one()
+      {
+        auto n = start;
+        if (n == nullptr)
+        {
+          return nullptr;
+        }
+
+        Systematic::yield();
+
+        auto next = n->next_in_queue.load(std::memory_order_acquire);
+        if (next == nullptr)
+        {
+          return nullptr;
+        }
+
+        start = next;
+        return n;
+      }
+    };
+
+    explicit MPMCQ() {}
 
     /**
      * Enqueue a node, this is not linearisable with respect
@@ -74,28 +100,34 @@ namespace verona::rt
      * once we return, due to other enqueues that have not
      * completed.
      */
-    void enqueue(T* node)
+    void enqueue_segment(Segment ls)
     {
-      node->next_in_queue.store(nullptr, std::memory_order_relaxed);
-      auto b = back.exchange(node, std::memory_order_seq_cst);
+      Systematic::yield();
+
+      ls.end->store(nullptr, std::memory_order_relaxed);
+
+      Systematic::yield();
+
+      auto b = back.exchange(ls.end, std::memory_order_seq_cst);
+
+      Systematic::yield();
+
       // The element we are writing into must have made its next pointer null
       // before exchanging into the structure, as the element cannot be removed
       // if it has a null next pointer, we know the write is safe.
-      assert(b->next_in_queue == nullptr);
-      b->next_in_queue.store(node, std::memory_order_release);
+      assert(b->load() == nullptr);
+      b->store(ls.start, std::memory_order_release);
+    }
+
+    void enqueue(T* node)
+    {
+      enqueue_segment({node, &node->next_in_queue});
     }
 
     void enqueue_front(T* node)
     {
-      auto cmp = front.read();
-
-      do
-      {
-        node->next_in_queue.store(cmp.ptr(), std::memory_order_relaxed);
-      } while (!cmp.store_conditional(node));
-      // TODO: Add this into the ABA protection.
-      // Requires snmalloc PR to add store_conditional to take a memory_order.
-      std::atomic_thread_fence(std::memory_order_seq_cst);
+      // No longer support put on the back.
+      enqueue_segment({node, &node->next_in_queue});
     }
 
     /**
@@ -104,81 +136,79 @@ namespace verona::rt
      */
     T* dequeue()
     {
-      T* next;
-      T* fnt;
+      auto old_front = acquire_front();
 
-      // Hold epoch to ensure that the value read from `front` cannot be
-      // deallocated during this operation.  This must occur before read of
-      // front.
-      Epoch e;
-      uint64_t epoch = e.get_local_epoch_epoch();
+      Systematic::yield();
 
-      auto cmp = front.read();
-      do
+      // Queue is empty or someone else is stealing, and hence it will be empty
+      if (old_front == nullptr)
       {
-        fnt = cmp.ptr();
-        // This operation is memory safe due to holding the epoch.
-        next = fnt->next_in_queue.load(std::memory_order_acquire);
+        return nullptr;
+      }
 
-        // If next is nullptr, then this is most likely the next entry has not
-        // been enqueued.  Due to the non-linearisable nature, there may be
-        // completed enqueues that are not visible.  This means we can get
-        // spurious failures and the context must cope with this. It may also
-        // return nullptr, due to an ABA where next is observed to be nullptr
-        // after the element has been removed.  This spurious nullptr could be
-        // removed by adding ABA protection, however, as the context must
-        // already deal with spurious failure, we do not bother with that check.
-        if (next == nullptr)
-          return nullptr;
-      } while (!cmp.store_conditional(next));
+      auto new_front = old_front->next_in_queue.load(std::memory_order_acquire);
 
-      assert(epoch != T::NO_EPOCH_SET);
+      Systematic::yield();
 
-      fnt->epoch_when_popped = epoch;
+      if (new_front != nullptr)
+      {
+        // Remove one element from the queue
+        front.store(new_front, std::memory_order_release);
+        return old_front;
+      }
 
-      return fnt;
-    }
+      Systematic::yield();
 
-    // The callers are expected to guarantee no one is attempting to access the
-    // queue concurrently.
-    void destroy()
-    {
-      assert(front.peek() == back);
-      auto b = back.load();
-      assert(b->next_in_queue == nullptr);
+      // Queue contains a single element, attempt to close the queue
+      auto next_ptr = &old_front->next_in_queue;
+      if (back.compare_exchange_strong(
+            next_ptr,
+            &front,
+            std::memory_order_acq_rel,
+            std::memory_order_relaxed))
+        return old_front;
 
-      heap::dealloc(b);
+      Systematic::yield();
+
+      // Failed to close the queue, something is being added, try again later.
+      front.store(old_front, std::memory_order_release);
+      return nullptr;
     }
 
     /**
-     * Returns true if nothing older than this call is in the queue.
-     *
-     * This is not linearisable, so a linearisable is_empty check is not
-     * possible.
-     *
-     * We use a happens-before semantics to explain its behaviour. If this
-     * returns true, then all enqueues that 'happened-before' this call, have
-     * been dequeued by the time this call returns. Parallel enqueues may or
-     * may-not be observed, so it may not be empty when it returns.
-     *
-     * The precise semantics of this are required for `unpause`/`pause`.  If
-     * during `pause`, we observe `nothing_old` to be true, then anything that
-     * is in the queue after this function returns must have been added not
-     * happens-before this call. As any addition must call `unpause` afterwards,
-     * we know that we can't read `nothing_old` as true, and then go to sleep
-     * with stuff still in our queue, as the `unpause` is guaranteed to wake us
-     * up.
+     * Take all elements from the queue.
+     * This may spuriosly fail and surrounding code should be prepared for that.
      */
-    bool nothing_old()
+    Segment dequeue_all()
     {
-      auto local_back = back.load(std::memory_order_acquire);
-      // Check if last element is the token cown.
-      // Last element should be the token work, but we don't need to check that
-      // as something else will have two things if we don't have the token.
+      auto old_front = acquire_front();
 
-      // Check first element is the last, hence if true, then all elements
-      // in the queue have been enqueued since this call started.
-      return local_back == front.peek();
+      // Queue is empty or someone else is popping, so just return.
+      if (old_front == nullptr)
+      {
+        return {nullptr, nullptr};
+      }
+
+      Systematic::yield();
+
+      auto old_back = back.exchange(&front, std::memory_order_acq_rel);
+
+      Systematic::yield();
+
+      return {old_front, old_back};
+    }
+
+    bool is_empty()
+    {
+      Systematic::yield();
+
+      return back.load(std::memory_order_acquire) == &front;
+    }
+
+    ~MPMCQ()
+    {
+      // Ensure that the queue is empty before destruction.
+      assert(is_empty());
     }
   };
 } // namespace verona::rt

--- a/src/rt/sched/mpmcq.h
+++ b/src/rt/sched/mpmcq.h
@@ -126,8 +126,17 @@ namespace verona::rt
 
     void enqueue_front(T* node)
     {
-      // No longer support put on the back.
-      enqueue_segment({node, &node->next_in_queue});
+      auto old_front = acquire_front();
+      if (old_front == nullptr)
+      {
+        // Post to back.
+        enqueue(node);
+        return;
+      }
+
+      // Link into the front.
+      node->next_in_queue.store(old_front, std::memory_order_relaxed);
+      front.store(node, std::memory_order_release);
     }
 
     /**

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -218,7 +218,6 @@ namespace verona::rt
         {
           Logging::cout() << "Destroying core " << core->affinity
                           << Logging::endl;
-          core->q.destroy();
         }
       }
 

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -234,16 +234,13 @@ namespace verona::rt
     {
       Work* work = nullptr;
       // Try to steal from the victim thread.
-      if (victim != core)
-      {
-        work = victim->q.dequeue();
+      work = core->q.steal(victim->q);
 
-        if (work != nullptr)
-        {
-          // stats.steal();
-          Logging::cout() << "Fast-steal work " << work << " from "
-                          << victim->affinity << Logging::endl;
-        }
+      if (work != nullptr)
+      {
+        core->stats.steal();
+        Logging::cout() << "Fast-steal work " << work << " from "
+                        << victim->affinity << Logging::endl;
       }
 
       // Move to the next victim thread.
@@ -268,17 +265,14 @@ namespace verona::rt
           return work;
 
         // Try to steal from the victim thread.
-        if (victim != core)
-        {
-          work = victim->q.dequeue();
+        work = core->q.steal(victim->q);
 
-          if (work != nullptr)
-          {
-            core->stats.steal();
-            Logging::cout() << "Stole work " << work << " from "
-                            << victim->affinity << Logging::endl;
-            return work;
-          }
+        if (work != nullptr)
+        {
+          core->stats.steal();
+          Logging::cout() << "Stole work " << work << " from "
+                          << victim->affinity << Logging::endl;
+          return work;
         }
 
         // We were unable to steal, move to the next victim thread.

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -288,7 +288,7 @@ namespace verona::rt
       {
         Logging::cout() << "Checking for pending work on thread " << c->affinity
                         << Logging::endl;
-        if (!c->q.nothing_old())
+        if (!c->q.is_empty())
         {
           Logging::cout() << "Found pending work!" << Logging::endl;
           return true;

--- a/src/rt/sched/work.h
+++ b/src/rt/sched/work.h
@@ -42,7 +42,6 @@ namespace verona::rt
      */
     void dealloc()
     {
-      auto& alloc = ThreadAlloc::get();
       heap::dealloc(this);
     }
   };

--- a/src/rt/sched/work.h
+++ b/src/rt/sched/work.h
@@ -19,18 +19,8 @@ namespace verona::rt
    */
   struct Work
   {
-    static constexpr auto NO_EPOCH_SET = (std::numeric_limits<uint64_t>::max)();
-
-    // Entry in the MPMC Queue of work items per scheduler.
-    union
-    {
-      // When in the queue this references the next element
-      std::atomic<Work*> next_in_queue;
-      // When not in the queue this is the epoch that it was last seen in the
-      // queue. This is used to allow deferred deallocation to be more
-      // efficient.
-      uint64_t epoch_when_popped{NO_EPOCH_SET};
-    };
+    // This references the next element in the queue.
+    std::atomic<Work*> next_in_queue{nullptr};
 
     // The function to execute this work item. It is supplied with a self
     // pointer and is responsible for all casting and memory management.
@@ -47,34 +37,13 @@ namespace verona::rt
     /**
      * Helper to perform deallocation.
      *
-     * Due to complexity with the MPMCQ memory management there is an
-     * epoch mechanism to prevent the underlying allocator decommitting
-     * the memory and thus causing a segfault.  This correctly deallocates
-     * a work item.
-     *
      * It assumes the work item is the start of an underlying allocation, and
      * does not work if it is embedded not at the start of an allocation.
      */
     void dealloc()
     {
-      auto epoch = epoch_when_popped;
-      auto outdated = epoch == NO_EPOCH_SET || GlobalEpoch::is_outdated(epoch);
-      if (outdated)
-      {
-        Logging::cout() << "Work " << this << " dealloc" << Logging::endl;
-        heap::dealloc(this);
-      }
-      else
-      {
-        Logging::cout() << "Work " << this << " defer dealloc" << Logging::endl;
-        // There could be an ABA problem if we reuse this work as the epoch
-        // has not progressed enough We delay the deallocation until the epoch
-        // has progressed enough
-        // TODO: We are waiting too long as this is inserting in the current
-        // epoch, and not `epoch` which is all that is required.
-        Epoch e;
-        e.delete_in_epoch(this);
-      }
+      auto& alloc = ThreadAlloc::get();
+      heap::dealloc(this);
     }
   };
 
@@ -108,9 +77,8 @@ namespace verona::rt
      * The pointer it returns is owning.
      *
      * t_param expected to be a bool returning thunk. If it returns true, then
-     * the `Work` will be deallocated (subject to epoch checks).  If it returns
-     * false, then the `Work` will not be deallocated, and the thunk is free to
-     * reschedule itself.
+     * the `Work` will be deallocated.  If it returns false, then the `Work`
+     * will not be deallocated, and the thunk is free to reschedule itself.
      */
     template<typename T>
     static Work* make(T&& t_param)

--- a/src/rt/sched/workstealingqueue.h
+++ b/src/rt/sched/workstealingqueue.h
@@ -47,8 +47,7 @@ namespace verona::rt
 
     void enqueue_front(Work* work)
     {
-      // TODO should this be --dequeue_index?
-      queues[++enqueue_index].enqueue_front(work);
+      queues[dequeue_index--].enqueue_front(work);
     }
 
     // Dequeue a single node from any of the queues.

--- a/src/rt/sched/workstealingqueue.h
+++ b/src/rt/sched/workstealingqueue.h
@@ -1,0 +1,129 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#include "../ds/wrapindex.h"
+#include "mpmcq.h"
+#include "work.h"
+
+namespace verona::rt
+{
+  template<size_t N>
+  class WorkStealingQueue
+  {
+    WrapIndex<N> enqueue_index{};
+    WrapIndex<N> dequeue_index{};
+    WrapIndex<N> steal_index{};
+
+    MPMCQ<Work> queues[N];
+
+    // Enqueue an entire segment onto the next enqueue queue.
+    // Works in a round robin fashion.
+    void enqueue(MPMCQ<Work>::Segment ls)
+    {
+      queues[++enqueue_index].enqueue_segment(ls);
+    }
+
+    // Take a segment and spread it across the queues
+    // using a round robin strategy.
+    void enqueue_spread(MPMCQ<Work>::Segment ls)
+    {
+      while (true)
+      {
+        auto n = ls.take_one();
+        if (n == nullptr)
+          break;
+        enqueue(n);
+      }
+      enqueue(ls);
+    }
+
+  public:
+    constexpr WorkStealingQueue() {}
+
+    // Enqueue a single node onto the next enqueue queue.
+    void enqueue(Work* work)
+    {
+      enqueue({work, &work->next_in_queue});
+    }
+
+    void enqueue_front(Work* work)
+    {
+      // TODO should this be --dequeue_index?
+      queues[++enqueue_index].enqueue_front(work);
+    }
+
+    // Dequeue a single node from any of the queues.
+    // Returns nullptr if no node is available.
+    Work* dequeue()
+    {
+      // Try each queue once.
+      for (size_t i = 0; i < N; ++i)
+      {
+        auto n = queues[++dequeue_index].dequeue();
+        if (n != nullptr)
+        {
+          return n;
+        }
+      }
+
+      return nullptr;
+    }
+
+    /**
+     * Steal work from the victim.
+     * Stealing has the side effect of placing work from the victim onto all the
+     * queues. Returns nullptr if no work could be stolen. This may spuriously
+     * return nullptr in the case where the first link in the segment has not
+     * been created, and there are more than two elements.
+     */
+    Work* steal(WorkStealingQueue& victim)
+    {
+      if (&victim == this)
+      {
+        // Don't steal from yourself.
+        // As scheduler loops around all the queues, use this to change the
+        // index.
+        ++steal_index;
+        return nullptr;
+      }
+
+      auto ls = victim.queues[steal_index].dequeue_all();
+
+      auto r = ls.take_one();
+      if (r == nullptr)
+      {
+        // take_one can fail for three reasons:
+        //  * fully empty
+        //  * single element
+        //  * first link in segment assignment has not become visible
+        // Handle single element segment case
+        if (ls.end == nullptr)
+        {
+          // Fully empty case
+          return nullptr;
+        }
+
+        if (ls.start != nullptr && ls.end == &ls.start->next_in_queue)
+        {
+          // Single element queue.
+          return ls.start;
+        }
+      }
+
+      enqueue_spread(ls);
+      return r;
+    }
+
+    bool is_empty()
+    {
+      for (size_t i = 0; i < N; ++i)
+      {
+        if (!queues[i].is_empty())
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
+  };
+} // namespace verona::rt

--- a/test/func/fair_variance/fair_variance.cc
+++ b/test/func/fair_variance/fair_variance.cc
@@ -10,7 +10,7 @@ using namespace snmalloc;
 using namespace verona::rt;
 using namespace verona::cpp;
 
-static constexpr int start_count = 1'00'000;
+static constexpr int start_count = 1'000'000;
 struct A
 {
   int id;
@@ -71,9 +71,10 @@ void assert_variance()
   {
     printf("cown[%d] took %f\n", i, elapsed_secs[i]);
   }
-  if ((max - min) / max > 0.15)
+  auto variance = (max - min) / max;
+  printf("(max - min) / max = %f\n", variance);
+  if (variance > 0.15)
   {
-    printf("(max - min) / max = %f\n", (max - min) / max);
     printf("variance too large");
     check(false);
   }

--- a/test/perf/worksteal/worksteal.cc
+++ b/test/perf/worksteal/worksteal.cc
@@ -1,0 +1,97 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+/**
+ * This benchmark is for testing performance of the work stealing code.
+ *
+ * A single behaviour generates all the work, which then needs dividing amongst
+ * the scheduler threads.
+ *
+ * There are two types of work that are generated
+ *   - nop: does nothing
+ *   - work: schedules a an item on sync to count down to monitor the time taken
+ *
+ * Basic shape is
+ *
+ *   sync -> nop
+ *        -> nop
+ *        -> nop
+ *        -> nop
+ *        -> work -> sync
+ *        ...
+ *
+ * The time taken to schedule all the work is measured.
+ * The time taken to execute all the work is measured.
+ *
+ * The core aim is to generate a lot of work on a single scheduler thread to tax
+ * the work stealing code.  As the main behaviour in test is long running,
+ * stealing work items from the scheduler thread that runs it is essential.
+ *
+ * We generate a nop work so that not everything has to contend for the sync
+ * cown to complete.
+ */
+
+#include "debug/log.h"
+#include "test/opt.h"
+#include "test/xoroshiro.h"
+#include "verona.h"
+
+#include <chrono>
+#include <cpp/when.h>
+#include <debug/harness.h>
+
+using namespace verona::cpp;
+
+struct Sync
+{
+  high_resolution_clock::time_point start{};
+  high_resolution_clock::time_point end{};
+  size_t remaining_count{0};
+};
+
+void test()
+{
+  auto sync = verona::cpp::make_cown<Sync>();
+
+  when(sync) << [](auto sync) {
+    sync->start = high_resolution_clock::now();
+
+    sync->remaining_count = 1'000'000;
+
+    for (size_t i = 0; i < sync->remaining_count; i++)
+    {
+      // Schedule some work to be done
+      when() << []() {};
+      when() << []() {};
+      when() << []() {};
+      when() << []() {};
+      // Every 5th work item will be counted back in for timing purposes
+      when() << [sync = sync.cown()]() {
+        when(sync) << [](auto sync) {
+          // Check if this is the last work item
+          if (--sync->remaining_count == 0)
+          {
+            sync->end = high_resolution_clock::now();
+            printf(
+              "Elapsed:\n\t%zu ms\n",
+              duration_cast<milliseconds>(sync->end - sync->start).count());
+            return;
+          }
+        };
+      };
+    }
+    printf(
+      "Scheduled all work took:\n\t%zu ms\n",
+      duration_cast<milliseconds>(high_resolution_clock::now() - sync->start)
+        .count());
+  };
+}
+
+int main(int argc, char** argv)
+{
+  SystematicTestHarness harness(argc, argv);
+
+  harness.run(test);
+
+  return 0;
+}


### PR DESCRIPTION
During @vishalgupta97 internship we observed problems with the work stealing algorithm that if all the work was generated by a single scheduler thread, then the other threads had heavy contention in the stealing code.  This is due to the stealing code only stealing a single item at a time.

There are a few papers that suggest stealing in larger units than single work items:

* [The Natural Work-Stealing Algorithm is Stable](https://www.cs.ox.ac.uk/people/leslieann.goldberg/papers/ws.pdf)
* [Scalable Work Stealing](https://dl.acm.org/doi/pdf/10.1145/1654059.1654113)
* [Hierarchical Work Stealing on Manycore Clusters](https://crd.lbl.gov/assets/pubs_presos/task.pdf)

The suggestions is that stealing at most half of the work is sensible.

This PR changes the implementation of the scheduler queues to support a steal all operation.  By providing N (N=4 in the PR) queues per scheduler thread, then we are able to steal approximately 1/4 of the work on a scheduler thread.

The PR adds a very simple benchmark where a single behaviour generates all the work in the system.  Configured with 4 cores, we get

Before this PR:
```
Scheduled all work took:
        317 ms
Elapsed:
        606 ms
```

While with his PR:
```
Scheduled all work took:
        234 ms
Elapsed:
        251 ms
```

This is running on my laptop with just four cores, so bigger experiments should be undertaken.

There is also a lot of opportunity for further investigations, in terms of different strategies for stealing and scheduling work.  This PR represents a simple position that improves the state of the system.
