### PR TITLE
Encapsulate PRNG usage

### DIFF
--- a/src/rt/debug/systematic.h
+++ b/src/rt/debug/systematic.h
@@ -4,8 +4,8 @@
 
 #include "../debug/logging.h"
 #include "../pal/semaphore.h"
+#include "ds/prng.h"
 #include "ds/scramble.h"
-#include "test/xoroshiro.h"
 
 #include <snmalloc/snmalloc.h>
 
@@ -86,9 +86,9 @@ namespace verona::rt
     /// Return a mutable reference to the pseudo random number generator (PRNG).
     /// It is assumed that the PRNG will only be setup once via `set_seed`.
     /// After it is setup, the PRNG must only be used via `get_prng_next`.
-    static xoroshiro::p128r32& get_prng_for_setup()
+    static PRNG<>& get_prng_for_setup()
     {
-      static xoroshiro::p128r32 prng;
+      static PRNG<> prng;
       return prng;
     }
 
@@ -96,9 +96,9 @@ namespace verona::rt
     /// scrambler will only be setup once via `set_seed`. After it is setup, the
     /// scrambler must only be accessed via a const reference
     /// (see `get_scrambler`).
-    static verona::Scramble& get_scrambler_for_setup()
+    static verona::rt::Scramble& get_scrambler_for_setup()
     {
-      static verona::Scramble scrambler;
+      static verona::rt::Scramble scrambler;
       return scrambler;
     }
 
@@ -113,7 +113,7 @@ namespace verona::rt
     }
 
     /// Return a const reference to the scrambler.
-    static const verona::Scramble& get_scrambler()
+    static const verona::rt::Scramble& get_scrambler()
     {
       return get_scrambler_for_setup();
     }
@@ -121,7 +121,7 @@ namespace verona::rt
     static void set_seed(uint64_t seed)
     {
       auto& rng = get_prng_for_setup();
-      rng.set_state(seed);
+      rng.set_seed(seed);
       get_scrambler_for_setup().setup(rng);
     }
 

--- a/src/rt/ds/prng.h
+++ b/src/rt/ds/prng.h
@@ -1,0 +1,81 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <random>
+#include <test/xoroshiro.h>
+
+namespace verona::rt
+{
+  // Template parameter expresses if the context is multi-threaded
+  template<bool Multithreaded = false>
+  class PRNG
+  {
+    static constexpr bool ThreadSafeRequired =
+#ifdef USE_SYSTEMATIC_TESTING
+      // If we are using systematic testing, then the PRNG does not need to be
+      // thread safe, even when called by multiple threads
+      false;
+#else
+      Multithreaded;
+#endif
+
+    std::conditional_t<ThreadSafeRequired, std::mt19937_64, xoroshiro::p128r32>
+      rng;
+
+    void set_seed(std::mt19937_64& r, uint64_t seed)
+    {
+      r.seed(seed);
+    }
+
+    void set_seed(xoroshiro::p128r32& r, uint64_t seed)
+    {
+      r.set_state(seed);
+    }
+
+    uint32_t next(std::mt19937_64& r)
+    {
+      return r();
+    }
+
+    uint32_t next(xoroshiro::p128r32& r)
+    {
+      return r.next();
+    }
+
+  public:
+    PRNG() : rng(5489) {}
+
+    PRNG(uint64_t seed)
+    {
+      set_seed(seed);
+    }
+
+    void set_seed(uint64_t seed)
+    {
+      set_seed(rng, seed);
+      // Discard the first 10 values to avoid correlation with the seed.
+      // Otherwise, using adjacent seeds will result in poor initial
+      // randomness.
+      for (size_t i = 0; i < 10; i++)
+        next();
+    }
+
+    uint32_t next()
+    {
+      return next(rng);
+    }
+
+    uint32_t next(uint32_t max)
+    {
+      return next() % max;
+    }
+
+    uint64_t next64()
+    {
+      auto top = next();
+      auto bottom = next();
+      return (static_cast<uint64_t>(top) << 32) | bottom;
+    }
+  };
+} // namespace verona::rt

--- a/src/rt/ds/scramble.h
+++ b/src/rt/ds/scramble.h
@@ -1,13 +1,14 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
 #pragma once
-#include "test/xoroshiro.h"
+
+#include "ds/prng.h"
 
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
 
-namespace verona
+namespace verona::rt
 {
   /**
    * This class is used to provide alternative orderings on a pointer type.
@@ -35,7 +36,7 @@ namespace verona
   public:
     Scramble() {}
 
-    void setup(xoroshiro::p128r32& r)
+    void setup(verona::rt::PRNG<>& r)
     {
       for (size_t i = 0; i < ROUNDS; i++)
       {

--- a/test/func/cownchain/cownchain.cc
+++ b/test/func/cownchain/cownchain.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <debug/harness.h>
-#include <test/xoroshiro.h>
 /**
  * This example is design to test a long chain of cowns being collected.
  **/

--- a/test/func/cowngc4/cowngc4.cc
+++ b/test/func/cowngc4/cowngc4.cc
@@ -252,7 +252,8 @@ struct Ping
 
   RCown<region_type>* rcown;
   PRNG<true>* rand;
-  Ping(RCown<region_type>* rcown, PRNG<true>* rand) : rcown(rcown), rand(rand) {}
+  Ping(RCown<region_type>* rcown, PRNG<true>* rand) : rcown(rcown), rand(rand)
+  {}
 
   void operator()()
   {

--- a/test/func/diningphilosophers/diningphil.cc
+++ b/test/func/diningphilosophers/diningphil.cc
@@ -144,8 +144,8 @@ void test_dining(
     Logging::cout() << "Fork " << i << " " << f << std::endl;
   }
 
-  verona::Scramble scrambler;
-  xoroshiro::p128r32 rand(h->current_seed());
+  verona::rt::Scramble scrambler;
+  verona::rt::PRNG<> rand{h->current_seed()};
 
   for (size_t i = 0; i < philosophers; i++)
   {

--- a/test/func/freeze/freeze.cc
+++ b/test/func/freeze/freeze.cc
@@ -1,7 +1,7 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
 #include "debug/harness.h"
-#include "test/xoroshiro.h"
+#include "ds/prng.h"
 
 #include <vector>
 #include <verona.h>
@@ -393,7 +393,7 @@ void test_random(size_t seed = 1, size_t max_edges = 128)
   heap::debug_check_empty();
   size_t id = 0;
 
-  xoroshiro::p128r32 r(seed);
+  PRNG<> r(seed);
   Symbolic* root = new (RegionType::Trace) Symbolic;
 #ifndef NDEBUG
   bool* reach = new bool[max_edges * max_edges];

--- a/test/func/hashmap/hashmap.cc
+++ b/test/func/hashmap/hashmap.cc
@@ -3,8 +3,8 @@
 #include "ds/hashmap.h"
 
 #include "debug/harness.h"
+#include "ds/prng.h"
 #include "test/opt.h"
-#include "test/xoroshiro.h"
 #include "verona.h"
 
 #include <unordered_map>
@@ -64,7 +64,7 @@ bool test(size_t seed)
   ObjectMap<std::pair<Key*, int32_t>> map;
   std::unordered_map<Key*, int32_t> model;
 
-  xoroshiro::p128r64 rng{seed};
+  verona::rt::PRNG<> rng{seed};
   std::stringstream err;
 
   map.debug_layout(err) << "\n";
@@ -102,7 +102,7 @@ bool test(size_t seed)
       return false;
     }
 
-    if ((rng.next() % 10) == 0)
+    if ((rng.next(10)) == 0)
     {
       err << "update " << key << "\n";
       entry.second = -entry.second;
@@ -121,7 +121,7 @@ bool test(size_t seed)
       }
     }
 
-    if ((rng.next() % 10) == 0)
+    if ((rng.next(10)) == 0)
     {
       err << "erase " << key << "\n";
       model.erase(key);

--- a/test/func/scramble/scramble.cc
+++ b/test/func/scramble/scramble.cc
@@ -1,36 +1,80 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
+#include <ds/prng.h>
 #include <ds/scramble.h>
+#include <snmalloc/snmalloc.h>
+#include <test/opt.h>
 
 // Simple test that perm is not preserving orders.
-int main()
+int main(int argc, char** argv)
 {
-  xoroshiro::p128r32 r(2);
-  bool failed = false;
-  for (size_t i = 0; i < 100; i++)
+  opt::Opt opt(argc, argv);
+  const auto seed = opt.is<size_t>("--seed", snmalloc::Aal::tick());
+
+  verona::rt::PRNG<> r(seed);
+  size_t total = 0;
+  size_t square_diff_total = 0;
+  constexpr size_t n = 100;
+  constexpr size_t s = 1000;
+  for (size_t i = 0; i < n; i++)
   {
-    verona::Scramble s1;
+    verona::rt::Scramble s1;
     s1.setup(r);
 
-    verona::Scramble s2;
+    verona::rt::Scramble s2;
     s2.setup(r);
 
     size_t count = 0;
 
-    for (uintptr_t p = 0; p < 1000; p++)
+    for (uintptr_t p = 0; p < s; p++)
     {
       if ((s1.perm(p) < s1.perm(p + 1)) == (s2.perm(p) < s2.perm(p + 1)))
         count++;
     }
 
-    if (count > 550 || count < 450)
-    {
-      failed = true;
-      std::cout << "Count same: " << count << std::endl;
-    }
+    total += count;
+    auto abs_diff = count > (s / 2) ? count - (s / 2) : (s / 2) - count;
+    square_diff_total += abs_diff * abs_diff;
   }
+
+  auto mean = total / n;
+  auto variance = square_diff_total / n;
+
+  bool failed = false;
+
+  if (mean > (s / 2) + 10)
+  {
+    failed = true;
+    std::cout << "Mean is too high" << std::endl;
+  }
+
+  if (mean < (s / 2) - 10)
+  {
+    failed = true;
+    std::cout << "Mean is too low" << std::endl;
+  }
+
+  if (variance > s)
+  {
+    failed = true;
+    std::cout << "Variance is too high" << std::endl;
+  }
+
+  if (variance < s / 5)
+  {
+    failed = true;
+    std::cout << "Variance is too low" << std::endl;
+  }
+
   if (failed)
+  {
+    std::cout << "Test failed" << std::endl;
+    std::cout << "    " << argv[0] << " --seed " << seed << std::endl;
+    std::cout << "Mean: " << mean << std::endl;
+    std::cout << "Variance: " << variance << std::endl;
+
     return 1;
+  }
   else
     return 0;
 }

--- a/test/perf/backpressure3/backpressure3.cc
+++ b/test/perf/backpressure3/backpressure3.cc
@@ -13,7 +13,6 @@
 
 #include "debug/log.h"
 #include "test/opt.h"
-#include "test/xoroshiro.h"
 #include "verona.h"
 
 #include <chrono>
@@ -26,7 +25,7 @@ struct Sender;
 struct Receiver : public VCown<Receiver>
 {
   std::vector<Sender*>& senders;
-  xoroshiro::p128r32 rng;
+  PRNG<> rng;
   size_t msgs = 0;
   timer::time_point prev = timer::now();
 

--- a/test/perf/banking/pthread_banks.cc
+++ b/test/perf/banking/pthread_banks.cc
@@ -1,6 +1,7 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
 #include "args.h"
+#include "ds/prng.h"
 
 #include <algorithm>
 #include <cassert>
@@ -27,8 +28,8 @@ namespace
 void thread_main(size_t id)
 {
   size_t a, b;
-  xoroshiro::p128r64 rand;
-  rand.set_state(id + 1);
+  verona::rt::PRNG<> rand;
+  rand.set_seed(id + 1);
 
   for (size_t i = 0; i < (TRANSACTIONS / NUM_WORKERS); i++)
   {

--- a/test/perf/banking/verona_banks.cc
+++ b/test/perf/banking/verona_banks.cc
@@ -39,11 +39,11 @@ struct Worker
 {
   std::shared_ptr<Accounts> accounts;
 
-  xoroshiro::p128r64 rand;
+  verona::rt::PRNG<> rand;
 
   Worker(std::shared_ptr<Accounts> accounts, size_t seed) : accounts(accounts)
   {
-    rand.set_state(seed + 1);
+    rand.set_seed(seed + 1);
   }
 
   ~Worker()

--- a/test/perf/hashtable/hashtable.cc
+++ b/test/perf/hashtable/hashtable.cc
@@ -82,7 +82,7 @@ auto concurrency = std::make_shared<std::array<std::atomic<size_t>, 1024>>();
 void test_hash_table()
 {
   auto t1 = high_resolution_clock::now();
-  xoroshiro::p128r32 rand{Systematic::get_prng_next()};
+  PRNG<> rand{Systematic::get_prng_next()};
 
   std::shared_ptr<std::vector<cown_ptr<Bucket>>> buckets =
     std::make_shared<std::vector<cown_ptr<Bucket>>>();

--- a/test/perf/schedule/schedule.cc
+++ b/test/perf/schedule/schedule.cc
@@ -10,7 +10,6 @@
 
 #include "debug/log.h"
 #include "test/opt.h"
-#include "test/xoroshiro.h"
 #include "verona.h"
 
 #include <chrono>
@@ -29,11 +28,11 @@ size_t writes;
 struct LoopCown : public VCown<LoopCown>
 {
   size_t count;
-  xoroshiro::p128r32 rng;
+  PRNG<> rng;
 
   LoopCown(size_t count, size_t seed) : count(count)
   {
-    rng.set_state(seed);
+    rng.set_seed(seed);
   }
 
   void go()

--- a/test/perf/ubench/ubench.cc
+++ b/test/perf/ubench/ubench.cc
@@ -18,7 +18,6 @@
 
 #include "debug/log.h"
 #include "test/opt.h"
-#include "test/xoroshiro.h"
 #include "verona.h"
 
 #include <chrono>
@@ -37,7 +36,7 @@ namespace ubench
   struct Pinger : public rt::VCown<Pinger>
   {
     vector<Pinger*>& pingers;
-    xoroshiro::p128r32 rng;
+    rt::PRNG<> rng;
     size_t select_mod = 0;
     bool running = false;
     size_t count = 0;


### PR DESCRIPTION
Allow for us to more easily change the PRNG representation.

At startup run the PRNG a few times to reduce initial correlation in bottom bits.  Ultimately, we should update the PRNG to something better.