### PR TITLE
Fix move ownership in C++ API

### DIFF
--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -140,7 +140,7 @@ namespace verona::cpp
   template<typename T>
   auto convert_access(cown_ptr<T>&& c)
   {
-    return Access<T>(c);
+    return Access<T>(std::move(c));
   }
 
   template<typename T>

--- a/src/rt/sched/behaviourcore.h
+++ b/src/rt/sched/behaviourcore.h
@@ -824,12 +824,13 @@ namespace verona::rt
           // If the body is the same, then we have an overlap within a single
           // behaviour.
           auto body_next = bodies[std::get<0>(cown_to_behaviour_slot_map[i])];
+
+          // Check if the caller passed an RC and add to the total.
+          transfer_count +=
+            std::get<1>(cown_to_behaviour_slot_map[i])->is_move();
+
           if (body_next == body)
           {
-            // Check if the caller passed an RC and add to the total.
-            transfer_count +=
-              std::get<1>(cown_to_behaviour_slot_map[i])->is_move();
-
             Logging::cout() << "Duplicate " << cown << " for " << body
                             << " Index " << i << Logging::endl;
             // We need to reduce the execution count by one, as we can't wait

--- a/test/func/when-transfer/transfer.cc
+++ b/test/func/when-transfer/transfer.cc
@@ -64,7 +64,7 @@ void test_sched_many_move()
   Logging::cout() << "test_body()" << Logging::endl;
 
   auto log1 = make_cown<Body>();
-  auto log2 = cown_ptr<Body>(log1);
+  auto log2 = make_cown<Body>();
 
   (when(std::move(log1)) <<
    [=](auto) { Logging::cout() << "log" << Logging::endl; }) +
@@ -77,7 +77,7 @@ void test_sched_many_move_busy()
   Logging::cout() << "test_body()" << Logging::endl;
 
   auto log1 = make_cown<Body>();
-  auto log2 = cown_ptr<Body>(log1);
+  auto log2 = make_cown<Body>();
 
   when(log1) << [=](auto) { Logging::cout() << "log" << Logging::endl; };
   (when(std::move(log1)) <<
@@ -91,7 +91,7 @@ void test_sched_many_mixed()
   Logging::cout() << "test_body()" << Logging::endl;
 
   auto log1 = make_cown<Body>();
-  auto log2 = cown_ptr<Body>(log1);
+  auto log2 = make_cown<Body>();
 
   (when(log1) << [=](auto) { Logging::cout() << "log" << Logging::endl; }) +
     (when(std::move(log2)) <<
@@ -103,10 +103,23 @@ void test_sched_many_mixed_busy()
   Logging::cout() << "test_body()" << Logging::endl;
 
   auto log1 = make_cown<Body>();
-  auto log2 = cown_ptr<Body>(log1);
+  auto log2 = make_cown<Body>();
 
   when(log1) << [=](auto) { Logging::cout() << "log" << Logging::endl; };
   (when(log1) << [=](auto) { Logging::cout() << "log" << Logging::endl; }) +
+    (when(std::move(log2)) <<
+     [=](auto) { Logging::cout() << "log" << Logging::endl; });
+}
+
+void test_sched_many_move_same()
+{
+  Logging::cout() << "test_body()" << Logging::endl;
+
+  auto log1 = make_cown<Body>();
+  auto log2 = cown_ptr<Body>(log1);
+
+  (when(std::move(log1)) <<
+   [=](auto) { Logging::cout() << "log" << Logging::endl; }) +
     (when(std::move(log2)) <<
      [=](auto) { Logging::cout() << "log" << Logging::endl; });
 }
@@ -123,6 +136,7 @@ int main(int argc, char** argv)
   harness.run(test_sched_many_move_busy);
   harness.run(test_sched_many_mixed);
   harness.run(test_sched_many_mixed_busy);
+  harness.run(test_sched_many_move_same);
 
   return 0;
 }


### PR DESCRIPTION
This PR fixes a bug in the C++ API related to reference counting and moving the ownership of a cown when scheduling a behaviour.