### PR TITLE
Update to the latest snmalloc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(SNMALLOC_USE_CXX17 ON CACHE BOOL "Build snmalloc in legacy CXX17 mode as lon
 FetchContent_Declare(
   snmalloc
   GIT_REPOSITORY https://github.com/microsoft/snmalloc
-  GIT_TAG        d8f174c717500a834229da5f1f6bfe888442e81a
+  GIT_TAG        e6bf8570d003c7f219f0a24704ad263b5a321c1a
 )
 
 FetchContent_MakeAvailable(snmalloc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(SNMALLOC_USE_CXX17 ON CACHE BOOL "Build snmalloc in legacy CXX17 mode as lon
 FetchContent_Declare(
   snmalloc
   GIT_REPOSITORY https://github.com/microsoft/snmalloc
-  GIT_TAG        e6bf8570d003c7f219f0a24704ad263b5a321c1a
+  GIT_TAG        b8e28be14b3fd98e27c2fe87c0296570f6d3990e
 )
 
 FetchContent_MakeAvailable(snmalloc)

--- a/src/rt/debug/logging.h
+++ b/src/rt/debug/logging.h
@@ -185,7 +185,7 @@ namespace Logging
     }
   };
 
-  using LocalLogPool = snmalloc::Pool<LocalLog, snmalloc::Alloc::Config>;
+  using LocalLogPool = snmalloc::Pool<LocalLog>;
 
   class ThreadLocalLog
   {

--- a/src/rt/debug/systematic.h
+++ b/src/rt/debug/systematic.h
@@ -107,8 +107,7 @@ namespace verona::rt
       Local(size_t id) : systematic_id(id) {}
     };
 
-    static inline function_ref<bool()> true_thunk{
-      []() { return true; }};
+    static inline function_ref<bool()> true_thunk{[]() { return true; }};
 
   private:
     /// Currently running thread.  Points to a cyclic list of all the threads.

--- a/src/rt/debug/systematic.h
+++ b/src/rt/debug/systematic.h
@@ -13,6 +13,49 @@ namespace verona::rt
 {
   using namespace snmalloc;
 
+  /**
+   * Non-owning version of std::function. Wraps a reference to a callable object
+   * (eg. a lambda) and allows calling it through dynamic dispatch, with no
+   * allocation. This is useful in the allocator code paths, where we can't
+   * safely use std::function.
+   *
+   * Inspired by the C++ proposal:
+   * http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0792r2.html
+   */
+  template<typename Fn>
+  struct function_ref;
+
+  template<typename R, typename... Args>
+  struct function_ref<R(Args...)>
+  {
+    // The enable_if is used to stop this constructor from shadowing the default
+    // copy / move constructors.
+    template<
+      typename Fn,
+      typename =
+        std::enable_if_t<!std::is_same_v<std::decay_t<Fn>, function_ref>>>
+    function_ref(Fn&& fn)
+    {
+      data_ = static_cast<void*>(&fn);
+      fn_ = execute<Fn>;
+    }
+
+    R operator()(Args... args) const
+    {
+      return fn_(data_, args...);
+    }
+
+  private:
+    void* data_;
+    R (*fn_)(void*, Args...);
+
+    template<typename Fn>
+    static R execute(void* p, Args... args)
+    {
+      return (*static_cast<std::add_pointer_t<Fn>>(p))(args...);
+    };
+  };
+
   class Systematic
   {
     enum class SystematicState
@@ -40,7 +83,7 @@ namespace verona::rt
 
       /// Used to specify a condition when this thread should/could make
       /// progress.  It is used to implement condition variables.
-      snmalloc::function_ref<bool()> guard = true_thunk;
+      function_ref<bool()> guard = true_thunk;
 
       /// How many uninterrupted steps this threads has been selected to run
       /// for.
@@ -64,7 +107,7 @@ namespace verona::rt
       Local(size_t id) : systematic_id(id) {}
     };
 
-    static inline snmalloc::function_ref<bool()> true_thunk{
+    static inline function_ref<bool()> true_thunk{
       []() { return true; }};
 
   private:
@@ -233,7 +276,7 @@ namespace verona::rt
      * Switches thread in systematic testing and only returns once
      * guard evaluates to true.
      */
-    static void yield_until(snmalloc::function_ref<bool()> guard)
+    static void yield_until(function_ref<bool()> guard)
     {
       if constexpr (enabled)
       {

--- a/src/rt/ds/heap.h
+++ b/src/rt/ds/heap.h
@@ -9,44 +9,44 @@ namespace verona::rt::heap
 {
   inline void* alloc(size_t size)
   {
-    return snmalloc::ThreadAlloc::get().alloc(size);
+    return snmalloc::alloc(size);
   }
 
   template<size_t size>
   inline void* alloc()
   {
-    return snmalloc::ThreadAlloc::get().alloc<size>();
+    return snmalloc::alloc<size>();
   }
 
   inline void* calloc(size_t size)
   {
-    return snmalloc::ThreadAlloc::get().alloc<snmalloc::YesZero>(size);
+    return snmalloc::alloc<snmalloc::YesZero>(size);
   }
 
   template<size_t size>
   inline void* calloc()
   {
-    return snmalloc::ThreadAlloc::get().alloc<size, snmalloc::YesZero>();
+    return snmalloc::alloc<size, snmalloc::YesZero>();
   }
 
   inline void dealloc(void* ptr)
   {
-    return snmalloc::ThreadAlloc::get().dealloc(ptr);
+    return snmalloc::dealloc(ptr);
   }
 
   inline void dealloc(void* ptr, size_t size)
   {
-    return snmalloc::ThreadAlloc::get().dealloc(ptr, size);
+    return snmalloc::dealloc(ptr, size);
   }
 
   template<size_t size>
   inline void dealloc(void* ptr)
   {
-    return snmalloc::ThreadAlloc::get().dealloc<size>(ptr);
+    return snmalloc::dealloc<size>(ptr);
   }
 
   inline void debug_check_empty()
   {
-    snmalloc::debug_check_empty<snmalloc::Alloc::Config>();
+    snmalloc::debug_check_empty();
   }
 } // namespace verona::rt::heap

--- a/src/rt/ds/stack.h
+++ b/src/rt/ds/stack.h
@@ -165,7 +165,7 @@ namespace verona::rt
     }
 
     /// For all elements of the stack
-    template <typename F>
+    template<typename F>
     void forall(F&& apply)
     {
       T** curr = index;
@@ -310,9 +310,8 @@ namespace verona::rt
     }
 
     /// Apply function to every element of the stack.
-    template <typename F>
-    ALWAYSINLINE
-    void forall(F&& apply)
+    template<typename F>
+    ALWAYSINLINE void forall(F&& apply)
     {
       stack.forall(std::forward<F&&>(apply));
     }

--- a/src/rt/ds/stack.h
+++ b/src/rt/ds/stack.h
@@ -165,7 +165,8 @@ namespace verona::rt
     }
 
     /// For all elements of the stack
-    void forall(snmalloc::function_ref<void(T*)> apply)
+    template <typename F>
+    void forall(F&& apply)
     {
       T** curr = index;
 
@@ -309,10 +310,11 @@ namespace verona::rt
     }
 
     /// Apply function to every element of the stack.
+    template <typename F>
     ALWAYSINLINE
-    void forall(snmalloc::function_ref<void(T*)> apply)
+    void forall(F&& apply)
     {
-      stack.forall(apply);
+      stack.forall(std::forward<F&&>(apply));
     }
 
     ~Stack()

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -184,7 +184,7 @@ namespace verona::rt
     // snmalloc will ensure that Objects are properly aligned. However, in some
     // situations, e.g. allocating within a RegionArena, we still need to
     // ensure that pointers to objects are aligned.
-    static constexpr size_t ALIGNMENT = (1 << MIN_ALLOC_BITS);
+    static constexpr size_t ALIGNMENT = MIN_ALLOC_SIZE;
 
     /// This class represents the Verona object header.
     /// It is stored directly before a Verona object.

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -512,7 +512,7 @@ namespace verona::rt
     }
   };
 
-  using LocalEpochPool = snmalloc::Pool<LocalEpoch, snmalloc::Alloc::Config>;
+  using LocalEpochPool = snmalloc::Pool<LocalEpoch>;
 
   template<typename T, bool predicate(LocalEpoch* p, T t)>
   bool LocalEpoch::forall(T t)


### PR DESCRIPTION
* snmalloc::function_ref removed.  Added a function_ref to Systematic testing, and used templates elsewhere.
* MIN_ALLOC_BITS was removed, use MIN_ALLOC_SIZE instead.
* snmalloc heap API was improved to hide the thread alloc details.  Updated heap.h to reflect this.
* Updated epoch to use the new nicer pool API as old one removed.