### PR TITLE
Fix Asan support

### DIFF
--- a/src/rt/ds/heap.h
+++ b/src/rt/ds/heap.h
@@ -7,6 +7,58 @@
 
 namespace verona::rt::heap
 {
+#ifdef SNMALLOC_PASS_THROUGH
+  inline void* aligned_alloc_snmalloc_size(size_t size)
+  {
+    auto align = snmalloc::natural_alignment(size);
+    auto asize = snmalloc::bits::align_up(size, align);
+    return aligned_alloc(align, asize);
+  }
+
+  inline void* alloc(size_t size)
+  {
+    return aligned_alloc_snmalloc_size(size);
+  }
+
+  template<size_t size>
+  inline void* alloc()
+  {
+    return aligned_alloc_snmalloc_size(size);
+  }
+
+  inline void* calloc(size_t size)
+  {
+    auto p = aligned_alloc_snmalloc_size(size);
+    memset(p, 0, size);
+    return p;
+  }
+
+  template<size_t size>
+  inline void* calloc()
+  {
+    auto p = aligned_alloc_snmalloc_size(size);
+    memset(p, 0, size);
+    return p;
+  }
+
+  inline void dealloc(void* ptr)
+  {
+    free(ptr);
+  }
+
+  inline void dealloc(void* ptr, size_t size)
+  {
+    free(ptr);
+  }
+
+  template<size_t size>
+  inline void dealloc(void* ptr)
+  {
+    free(ptr);
+  }
+
+  inline void debug_check_empty() {}
+#else
   inline void* alloc(size_t size)
   {
     return snmalloc::alloc(size);
@@ -49,4 +101,5 @@ namespace verona::rt::heap
   {
     snmalloc::debug_check_empty();
   }
+#endif
 } // namespace verona::rt::heap


### PR DESCRIPTION
snmalloc removed support for PASS_THROUGH, as the refactor of verona-rt made it easier to do the pass through at the top, and not infect snmalloc with this requirement.

This fixes up the asan support to call suitably aligned allocations from asans allocator.