### PR TITLE
Cown duplicate

### DIFF
--- a/src/rt/cpp/behaviour.h
+++ b/src/rt/cpp/behaviour.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "behaviourcore.h"
+#include "../sched/behaviourcore.h"
 
 namespace verona::rt
 {
@@ -59,7 +59,8 @@ namespace verona::rt
     static void invoke(Work* work)
     {
       // Dispatch to the body of the behaviour.
-      Be* body = BehaviourCore::body_from_work<Be>(work);
+      BehaviourCore* b = BehaviourCore::from_work(work);
+      Be* body = b->get_body<Be>();
 
       (*body)();
       if (behaviour_rerun())

--- a/src/rt/cpp/lambdabehaviour.h
+++ b/src/rt/cpp/lambdabehaviour.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "../sched/notification.h"
+#include "notification.h"
 #include "behaviour.h"
 #include "vobject.h"
 

--- a/src/rt/cpp/lambdabehaviour.h
+++ b/src/rt/cpp/lambdabehaviour.h
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "../sched/behaviour.h"
 #include "../sched/notification.h"
+#include "behaviour.h"
 #include "vobject.h"
 
 namespace verona::rt

--- a/src/rt/cpp/lambdabehaviour.h
+++ b/src/rt/cpp/lambdabehaviour.h
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "notification.h"
 #include "behaviour.h"
+#include "notification.h"
 #include "vobject.h"
 
 namespace verona::rt

--- a/src/rt/cpp/notification.h
+++ b/src/rt/cpp/notification.h
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "behaviourcore.h"
-#include "shared.h"
+#include "../sched/shared.h"
+#include "behaviour.h"
 
 namespace verona::rt
 {

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "../sched/behaviour.h"
+#include "behaviour.h"
 #include "cown.h"
 #include "cown_array.h"
 

--- a/src/rt/sched/notification.h
+++ b/src/rt/sched/notification.h
@@ -55,8 +55,8 @@ namespace verona::rt
     static void invoke(Work* work)
     {
       // Dispatch to the body of the behaviour.
-      BehaviourWrapper<Be>* wrapper =
-        BehaviourCore::body_from_work<BehaviourWrapper<Be>>(work);
+      BehaviourCore* b = BehaviourCore::from_work(work);
+      BehaviourWrapper<Be>* wrapper = b->get_body<BehaviourWrapper<Be>>();
 
       Be& body = wrapper->body;
       auto notification = wrapper->notification;

--- a/src/rt/verona.h
+++ b/src/rt/verona.h
@@ -22,7 +22,6 @@
 #include "sched/epoch.h"
 #include "sched/mpmcq.h"
 #include "sched/noticeboard.h"
-#include "sched/notification.h"
 #include "sched/schedulerthread.h"
 
 #include <snmalloc/snmalloc.h>

--- a/test/func/lambdabehaviour/lambdabehaviour.cc
+++ b/test/func/lambdabehaviour/lambdabehaviour.cc
@@ -28,7 +28,7 @@ void lambda_smart()
 {
   auto a = make_unique<A>(42);
   schedule_lambda(
-    [a = move(a)]() { std::cout << "Hello " << a->v << std::endl; });
+    [a = std::move(a)]() { std::cout << "Hello " << a->v << std::endl; });
 }
 
 void lambda_args()


### PR DESCRIPTION
This changes from erasing a cown from the slots to marking it with a bit to signify it is a duplicate.  This enables the behaviour to look at the relevant slots for the cown rather than having to capture it separately in the closure.