### PR TITLE
Fix RC GC memory leak from missing Lins stack push

### DIFF
--- a/src/rt/region/region_rc.h
+++ b/src/rt/region/region_rc.h
@@ -609,6 +609,17 @@ namespace verona::rt
               p->finalise(nullptr, sub_regions);
               gc.push(p);
             }
+            else
+            {
+              // RC is still > 0, so this object may be part of a cycle.
+              // Push it onto the Lins stack as a candidate for cycle
+              // collection, matching the behaviour of decref().
+              if (p->get_rc_colour() != RcColour::BLACK)
+              {
+                p->set_rc_colour(RcColour::BLACK);
+                reg->lins_stack.push(p);
+              }
+            }
             break;
           case Object::SCC_PTR:
             p->immutable();

--- a/test/func/rc_distant_cycle/rc_distant_cycle.cc
+++ b/test/func/rc_distant_cycle/rc_distant_cycle.cc
@@ -1,0 +1,25 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "rc_distant_cycle.h"
+
+#include <debug/harness.h>
+#include <test/opt.h>
+
+int main(int argc, char** argv)
+{
+  opt::Opt opt(argc, argv);
+
+#ifdef CI_BUILD
+  auto log = true;
+#else
+  auto log = opt.has("--log-all");
+#endif
+
+  if (log)
+    Logging::enable_logging();
+
+  rc_distant_cycle::run_test();
+
+  return 0;
+}

--- a/test/func/rc_distant_cycle/rc_distant_cycle.h
+++ b/test/func/rc_distant_cycle/rc_distant_cycle.h
@@ -1,0 +1,66 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "../memory/memory.h"
+
+#include <vector>
+
+/**
+ * This tests if a cycle (n2->n3->n2) with just one external reference that is
+ * reachable from the root (n1) is correctly deallocated when we decref (and
+ * indirectly deallocate) that external reference.
+ **/
+namespace rc_distant_cycle
+{
+  using C = C1;
+
+  void test_distant_cycle()
+  {
+    auto* o = new (RegionType::Rc) C;
+    {
+      UsingRegion rc(o);
+
+      /**
+          Graph structure:
+                    ┌────┐
+                    │    ▼
+          o──►n1──►n2   n3
+                    ▲    │
+                    └────┘
+      **/
+      auto* n1 = new C;
+      auto* n2 = new C;
+      auto* n3 = new C;
+
+      o->f1 = n1;
+      n1->f1 = n2;
+      n2->f1 = n3;
+      n3->f1 = n2;
+
+      incref(n2);
+
+      o->f1 = nullptr; // remove o->n1
+      decref(n1); // decref n1, it should deallocate
+
+      check(debug_size() == 3); // only n1 should be deallocated so far
+
+      // Trigger cycle collection to try to collect n2->n3->n2 cycle
+      region_collect();
+
+      /**
+       * n1, n2 and n3 should be deallocated by now. A bug of debug_size == 3
+       * can arise if we don't add n2 to the lins stack when its ref count stays
+       * > 0 after n1 is deallocated and its reference is removed.
+       **/
+      check(debug_size() == 1);
+    }
+    region_release(o);
+  }
+
+  void run_test()
+  {
+    test_distant_cycle();
+  }
+}


### PR DESCRIPTION
The current implementation of the RC garbage collection strategy has a memory leak from a missing push of objects to the Lins stack if their reference count reduced outside of a direct call to `decref` (i.e., in `dealloc_object()`). In other words, if an object 'A' references another object 'B' that is in a cycle, if 'A' gets deallocated, 'B' will not be added to the Lins stack and, thus, will be unreachable from the root but also will be unable to be collected by `gc_cycles` causing a memory leak. This is outlined in the `rc_distant_cycle` test.

Changes:

- Added code to push objects onto the Lins stack in `region_rc.h` when their reference count is reduced outside of a direct call to decref (i.e., when it is reduced inside `dealloc_object()`).
- Added a test `rc_distant_cycle` to check for this bug.