### PR TITLE
Use DefaultPal::tick() for work-stealing quiescence timeout

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,9 @@ set(SNMALLOC_BUILD_TESTING OFF)
 # Don't add any of the targets to `all`.
 FetchContent_MakeAvailable_ExcludeFromAll(snmalloc)
 
-clangformat_targets(
-  INCLUDE_PATTERNS *.h *.cc
-)
+if(NOT DEFINED VERONA_RT_ONLY_HEADER_LIBRARY)
+  clangformat_targets(
+    INCLUDE_PATTERNS *.h *.cc
+  )
+endif()
 add_subdirectory(rt)

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -255,7 +255,7 @@ namespace verona::rt
 
     Work* steal()
     {
-      uint64_t tsc = Aal::tick();
+      uint64_t tsc = DefaultPal::tick();
       Work* work;
 
       while (running)
@@ -292,7 +292,7 @@ namespace verona::rt
         }
 #else
         // Wait until a minimum timeout has passed.
-        uint64_t tsc2 = Aal::tick();
+        uint64_t tsc2 = DefaultPal::tick();
         if ((tsc2 - tsc) < TSC_QUIESCENCE_TIMEOUT)
         {
           Aal::pause();


### PR DESCRIPTION
Upstream snmalloc changed Aal::tick() to return 0 on platforms without CPU cycle counter instructions. This caused the steal loop to spin indefinitely, as the elapsed time was always computed as 0 - 0 = 0, which never exceeds TSC_QUIESCENCE_TIMEOUT, preventing threads from reaching the pause/sleep state.

DefaultPal::tick() handles this correctly by falling back to clock_gettime(CLOCK_MONOTONIC) when cycle counters are unavailable.