### PR TITLE
sched: extend SchedulerStats with futex/pause diagnostics

### DIFF
--- a/src/rt/sched/schedulerstats.h
+++ b/src/rt/sched/schedulerstats.h
@@ -40,9 +40,14 @@ namespace verona::rt
   private:
 #ifdef USE_SCHED_STATS
     std::atomic<size_t> steal_count{0};
+    std::atomic<size_t> steal_attempt_count{0};
     std::atomic<size_t> pause_count{0};
+    std::atomic<size_t> pause_aborted_check_for_work_count{0};
+    std::atomic<size_t> pause_aborted_race_count{0};
     std::atomic<size_t> unpause_count{0};
     std::atomic<size_t> lifo_count{0};
+    std::atomic<size_t> sleep_count{0};
+    std::atomic<size_t> wake_count{0};
     std::array<std::atomic<size_t>, 16> behaviour_count{};
     std::atomic<size_t> cown_count{0};
 #endif
@@ -91,6 +96,58 @@ namespace verona::rt
 #endif
     }
 
+    /**
+     * Counts one entry into SleepHandle::sleep() i.e. one futex_wait syscall.
+     */
+    static void record_sleep()
+    {
+#ifdef USE_SCHED_STATS
+      get_global().sleep_count++;
+#endif
+    }
+
+    /**
+     * Counts one entry into SleepHandle::wake() i.e. one futex_wake syscall.
+     */
+    static void record_wake()
+    {
+#ifdef USE_SCHED_STATS
+      get_global().wake_count++;
+#endif
+    }
+
+    /**
+     * Counts one entry into SchedulerThread::steal() (own queue was empty).
+     */
+    void steal_attempt()
+    {
+#ifdef USE_SCHED_STATS
+      steal_attempt_count++;
+#endif
+    }
+
+    /**
+     * Counts one occasion where pause() aborted because
+     * check_for_work() found work after pause_epoch was bumped.
+     */
+    void pause_aborted_check_for_work()
+    {
+#ifdef USE_SCHED_STATS
+      pause_aborted_check_for_work_count++;
+#endif
+    }
+
+    /**
+     * Counts one occasion where pause() aborted because the
+     * unpause_epoch changed under the scheduler lock.
+     */
+    void pause_aborted_race()
+    {
+#ifdef USE_SCHED_STATS
+      pause_aborted_race_count++;
+#endif
+    }
+
     void behaviour(size_t cowns)
     {
       UNUSED(cowns);
@@ -115,9 +172,15 @@ namespace verona::rt
 
 #ifdef USE_SCHED_STATS
       steal_count += that.steal_count;
+      steal_attempt_count += that.steal_attempt_count;
       pause_count += that.pause_count;
+      pause_aborted_check_for_work_count +=
+        that.pause_aborted_check_for_work_count;
+      pause_aborted_race_count += that.pause_aborted_race_count;
       unpause_count += that.unpause_count;
       lifo_count += that.lifo_count;
+      sleep_count += that.sleep_count;
+      wake_count += that.wake_count;
       cown_count += that.cown_count;
 
       for (size_t i = 0; i < behaviour_count.size(); i++)
@@ -141,9 +204,14 @@ namespace verona::rt
             << "Tag"
             << "DumpID"
             << "Steal"
+            << "StealAttempt"
             << "LIFO"
             << "Pause"
+            << "PauseAbortCheckForWork"
+            << "PauseAbortRace"
             << "Unpause"
+            << "Sleep"
+            << "Wake"
             << "Cown count";
 
         for (size_t i = 0; i < behaviour_count.size(); i++)
@@ -153,16 +221,23 @@ namespace verona::rt
       }
 
       csv << "SchedulerStats" << get_tag() << dumpid << steal_count
-          << lifo_count << pause_count << unpause_count << cown_count;
+          << steal_attempt_count << lifo_count << pause_count
+          << pause_aborted_check_for_work_count << pause_aborted_race_count
+          << unpause_count << sleep_count << wake_count << cown_count;
 
       for (size_t i = 0; i < behaviour_count.size(); i++)
         csv << behaviour_count[i];
       csv << std::endl;
 
       steal_count = 0;
+      steal_attempt_count = 0;
       pause_count = 0;
+      pause_aborted_check_for_work_count = 0;
+      pause_aborted_race_count = 0;
       unpause_count = 0;
       lifo_count = 0;
+      sleep_count = 0;
+      wake_count = 0;
       cown_count = 0;
 
       for (size_t i = 0; i < behaviour_count.size(); i++)

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -255,6 +255,7 @@ namespace verona::rt
 
     Work* steal()
     {
+      core->stats.steal_attempt();
       uint64_t tsc = DefaultPal::tick();
       Work* work;
 

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -295,7 +295,10 @@ namespace verona::rt
 
       // Work has become available, we shouldn't pause.
       if (check_for_work())
+      {
+        local()->get_stats().pause_aborted_check_for_work();
         return false;
+      }
 
       yield();
 
@@ -305,7 +308,10 @@ namespace verona::rt
         // An unpause has occurred since, we started to pause.
         if (
           local_unpause_epoch != unpause_epoch.load(std::memory_order_relaxed))
+        {
+          local()->get_stats().pause_aborted_race();
           return false;
+        }
 
         // Check if we should wait for other threads to generate more work.
         auto value = state.get_active_threads();

--- a/src/rt/sched/threadsync.h
+++ b/src/rt/sched/threadsync.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "../pal/semaphore.h"
 #include "debug/logging.h"
+#include "schedulerstats.h"
 
 /**
  * This file contains the synchronisation implementation for suspending
@@ -122,6 +123,7 @@ namespace verona::rt
         while (curr != nullptr)
         {
           auto next = curr->next;
+          SchedulerStats::record_wake();
           curr->sem.wake();
           curr = next;
         }
@@ -170,6 +172,7 @@ namespace verona::rt
         sync.unlock();
 
         Logging::cout() << "Sleep" << Logging::endl;
+        SchedulerStats::record_sleep();
         thread->local_sync.sem.sleep();
         Logging::cout() << "Awake!" << Logging::endl;
 


### PR DESCRIPTION
Adds five new counters (gated on USE_SCHED_STATS) to make it possible to attribute kernel-time costs in the scheduler:

  - sleep_count / wake_count: number of actual SleepHandle::sleep() and SleepHandle::wake() calls. These are the real futex_wait / futex_wake syscalls. Distinct from pause_count, since one pause-protocol entry can either find work and abort (no sleep) or genuinely sleep, and one unpause_all() emits one wake per parked thread.

  - steal_attempt_count: every entry into SchedulerThread::steal(), not just the successful ones. Lets us reason about the ratio of own-queue-drains to successful steals to genuine pauses.

  - pause_aborted_check_for_work_count: pause-protocol aborted because check_for_work() saw work after the seq_cst barrier was bumped. A high value relative to pause_count means the cheap early-abort is doing its job and saving futex traffic.

  - pause_aborted_race_count: pause-protocol aborted because the unpause_epoch changed under the scheduler lock.

These hooks make it possible to validate scheduler claims like "the steal->pause path is responsible for X% of kernel time" empirically rather than by speculation, and to detect when OS-level preemption of behaviour-holders is cascading into scheduler pauses.

Counters add no cost when USE_SCHED_STATS is off (default).